### PR TITLE
Synthetic Clipboard

### DIFF
--- a/src/ClipboardHandler.js
+++ b/src/ClipboardHandler.js
@@ -1,72 +1,146 @@
-class ClipboardHandler extends Object {
+/**
+ * SyntheticClipboardHandler class
+ * -----------------------------------------
+ * I am a handler whose responsibility mimicks
+ * that of a clipboard when it comes to interacting
+ * with parts of an attached sheet instance.
+ * Because of the in-flux nature of the Clipboard API
+ * in today's browsers, there is limited interaction
+ * with OS-level copy and paste.
+ * Instead, I copy information from the sheet's selector
+ * and store it in myself, triggering `synthetic-copy`
+ * and `synthetic-paste` events on the sheet as needed.
+ * These events can be listened for by any consumers.
+ * The basis handlers for them defined here copy and paste
+ * SelectionFrame data.
+ */
+
+class SyntheticClipboardHandler extends Object {
     constructor(sheet){
-        super();
+        super(sheet);
         if(!sheet){
             throw new Error('You must initialize a ClipboardHandler with a valid sheet instance!');
         }
         this.sheet = sheet;
+        this.contents = [];
 
         // Bind component methods
         this.connect = this.connect.bind(this);
         this.disconnect = this.disconnect.bind(this);
         this.onCopy = this.onCopy.bind(this);
+        this.triggerCopyEvent = this.triggerCopyEvent.bind(this);
         this.onPaste = this.onPaste.bind(this);
-        this.onKeyDown = this.onKeyDown.bind(this);
+        this.triggerPasteEvent = this.triggerPasteEvent.bind(this);
+        this.handleKeyDown = this.handleKeyDown.bind(this);
+        this.frameContentsAsCsv = this.frameContentsAsCsv.bind(this);
+        this._manualCopy = this._manualCopy.bind(this);
     }
 
     connect(){
-        this.sheet.addEventListener('copy', this.onCopy);
-        this.sheet.addEventListener('paste', this.onPaste);
-        this.sheet.addEventListener('keydown', this.onKeyDown);
+        this.sheet.addEventListener('keydown', this.handleKeyDown);
+        this.sheet.addEventListener('synthetic-copy', this.onCopy);
+        this.sheet.addEventListener('synthetic-paste', this.onPaste);
     }
 
     disconnect(){
-        this.sheet.removeEventListener('copy', this.onCopy);
-        this.sheet.removeEventListener('paste', this.onPaste);
-        this.sheet.removeEventListener('keydown', this.onKeyDown);
+        this.sheet.removeEventListener('keydown', this.handleKeyDown);
+        this.sheet.removeEventListener('synthetic-copy', this.onCopy);
+        this.sheet.removeEventListener('synthetic-paste', this.onPaste);
     }
 
     onCopy(event){
-        console.log(event);
+        // Here we attempt to put the synthetic clipboard
+        // data into the real clipboard as CSV, so that
+        // the information can be OS-level pasted into
+        // other contexts.
+        this.contents.push(event.detail);
+        let csvString = this.frameContentsAsCsv(event.detail.data);
+        this._manualCopy(csvString);
     }
 
     onPaste(event){
-        console.log(event);
+        event.detail.contents.forEach(clipboardItem => {
+            let destOrigin = this.sheet.selector.selectionFrame.origin;
+            if(this.sheet.selector.selectionFrame.isEmpty){
+                destOrigin = this.sheet.selector.relativeCursor;
+            }
+            this.sheet.dataFrame.loadFromArray(clipboardItem.data, [destOrigin.x, destOrigin.y]);
+        });
     }
 
-    onKeyDown(event){
+    handleKeyDown(event){
         if(event.key == 'c' && event.ctrlKey){
-            let hiddenEl = document.createElement('div');
-            hiddenEl.style.display = "none";
-            document.body.append(hiddenEl);
-            // Set the textContent of the hidden el
-            // to be the CSV of the selection area
-            let lines = [];
-            this.sheet.selector.selectionFrame.forEachPointRow(row => {
-                let line = row.map(point => {
-                    let value = this.sheet.dataFrame.getAt(point);
-                    if (value.replace(/ /g, '').match(/[\s,"]/)) {
-                        return '"' + value.replace(/"/g, '""') + '"';
-                    }
-                    return value;
-                }).join(",");
-                lines.push(line);
-            });
-            hiddenEl.textContent = lines.join("\n");
-            let range = document.createRange();
-            range.selectNodeContents(hiddenEl);
-            let selection = document.getSelection();
-            selection.removeAllRanges();
-            selection.addRange(range);
-            document.execCommand('copy');
-            hiddenEl.remove();
             event.preventDefault();
             event.stopPropagation();
+            this.triggerCopyEvent();
+        } else if(event.key == 'v' && event.ctrlKey){
+            event.preventDefault();
+            event.stopPropagation();
+            this.triggerPasteEvent();
         }
+    }
+
+    triggerCopyEvent(){
+        let frame = this.sheet.selector.selectionFrame.copy();
+        let data = this.sheet.dataFrame.getDataArrayForFrame(frame);
+        let event = new CustomEvent('synthetic-copy', {
+            detail: {
+                type: 'frame-selection',
+                frame: frame,
+                data: data
+            }
+        });
+        this.sheet.dispatchEvent(event);
+    }
+
+    triggerPasteEvent(){
+        let event = new CustomEvent('synthetic-paste', {
+            detail: {
+                contents: this.contents.slice()
+            }
+        });
+        this.sheet.dispatchEvent(event);
+    }
+
+    frameContentsAsCsv(arrayData){
+        // Given a two-dimensional array
+        // of Frame values (as extracted from a DataFrame),
+        // respond with a string in CSV format
+        return arrayData.map(row => {
+            return row.map(item => {
+                let value = item.toString();
+                if (value.replace(/ /g, '').match(/[\s,"]/)) {
+                    return '"' + value.replace(/"/g, '""') + '"';
+                }
+                return value;
+            }).join(",");
+        }).join("\n");
+    }
+
+    _manualCopy(text){
+        // Use execCommand and a hidden element
+        // to select and then copy the given text,
+        // which is a CSV representation of the values
+        // from a SelectionFrame
+        let element = document.createElement('div');
+        element.setAttribute("contenteditable", true);
+        element.style.width = "0px";
+        element.style.height = "0px";
+        element.style.whiteSpace = "pre";
+        element.textContent = text;
+        document.body.append(element);
+        let selection = document.getSelection();
+        let range = document.createRange();
+        range.selectNodeContents(element);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        document.execCommand('copy');
+        element.remove();
+        this.sheet.focus();
     }
 }
 
 export {
-    ClipboardHandler,
-    ClipboardHandler as default
+    SyntheticClipboardHandler,
+    SyntheticClipboardHandler as default
 };

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -4,7 +4,7 @@ import PrimaryFrame from "./PrimaryGridFrame.js";
 import {Point} from "./Point.js";
 import {MouseHandler} from './MouseHandler.js';
 import {KeyHandler} from './KeyHandler.js';
-import {ClipboardHandler} from './ClipboardHandler.js';
+import {SyntheticClipboardHandler} from './ClipboardHandler.js';
 import {Frame} from "./Frame.js";
 
 // Simple grid-based sheet component
@@ -68,12 +68,20 @@ const templateString = `
     margin-left: 8px;
     margin-right: 6px;
 }
+#hidden-paste-area {
+    position: absolute;
+    width: 0px;
+    height: 0px;
+}
+
 </style>
+
 <div id="edit-bar">
     <div id="info-area"><span>Cursor</span><span>&rarr;</span></div>
     <input id="edit-area" type="text" disabled="true"/>
 </div>
 <slot></slot>
+<div id="hidden-paste-area" contenteditable="true"></div>
 `;
 
 class GridSheet extends HTMLElement {
@@ -81,7 +89,7 @@ class GridSheet extends HTMLElement {
         super();
         this.template = document.createElement('template');
         this.template.innerHTML = templateString;
-        this.attachShadow({mode: 'open'});
+        this.attachShadow({mode: 'open', delegatesFocus: true});
         this.shadowRoot.appendChild(
             this.template.content.cloneNode(true)
         );
@@ -141,7 +149,7 @@ class GridSheet extends HTMLElement {
 
             // Attach ClipboardHandler to handle
             // copy and paste
-            this.clipboardHandler = new ClipboardHandler(this);
+            this.clipboardHandler = new SyntheticClipboardHandler(this);
             this.clipboardHandler.connect();
         }
 


### PR DESCRIPTION
## What ##
This PR provides an initial implementation of a Sheet handler for clipboard-like events.
  
## Implementation ##
Because of browser inconsistencies in implementing the Clipboard API and currently allowed MIME types in that API, we cannot rely on it for copy and paste actions within the world of a Sheet. Therefore we introduce this handler, with its own `contents` array of clipboard items.
  
Each clipboard item in `contents` is an object with `frame` and `data` keys, the former being an actual `Frame` object (a selection frame) and the latter being the 2-dimensional array of values of that frame.
  
Instead of relying on OS-level `copy` and `paste` events, the handler uses CustomEvents called `synthetic-copy` and `synthetic-paste`, which it dispatches on the sheet whenever Ctrl-C/Ctrl-V are pressed (if the sheet is in focus). Any consumer can add listeners to these events on the sheet. And it turns out, the ClipboardHandler is itself the first consumer. Here is what the handler does in response to each event:
  
### on `synthetic-copy` ###
The incoming event object's details property contains the `frame` and `data` (2-dimensional array of frame values) acquired for the selection when copy was first dispatched. This is pushed to the internal `contents` array.
  
As an additional step, we use some well-worn hacks to compose a CSV string representation of the selection values and, with `document.execCommand` trickery, we get this string into the actual OS-level clipboard.
  
The upshot: if you paste into something else on your computer, the CSV representation will be pasted. But if you are pasting on a sheet, the SyntheticClipboardHandler will instead paste the more dynamic object values into the sheet (see below).
  
### on `synethetic-paste` ###
This event has no relation to the regular paste event. Instead, the handler grabs each clipboard object from its contents and loads the data into the target sheet starting at the origin specified by the current cursor.
  
## To Test ##
Load up the default example (`examples/index.html`) and copy some selection frame (ctrl-c), then move to another cell and paste (ctrl-v). The values should copy over instantly.