### PR TITLE
Columns, Rows, Selections, and Cursors

### DIFF
--- a/garbage.html
+++ b/garbage.html
@@ -68,6 +68,15 @@
                      el.textContent = `${colNum}, ${rowNum}`;
                      }
              }
+
+             // Example selection frame
+             let div = document.createElement('div');
+             div.style.backgroundColor = "rgba(220, 220, 220, 0.3)";
+             div.style.gridColumnStart = "cell-col-start 2";
+             div.style.gridColumnEnd = "cell-col-start -1";
+             div.style.gridRowStart = "cell-row-start 1";
+             div.style.gridRowEnd = "cell-row-start -1";
+             grid.append(div);
          });
         </script>
     </body>

--- a/garbage.html
+++ b/garbage.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Grid Experiments</title>
+    </head>
+    <body>
+        <main>
+            <div id="grid">
+            </div>
+        </main>
+        <style>
+         #grid {
+             display: grid;
+             grid-template-areas: "ctab ctab ctab ctab ctab ctab ctab ctab ctab ctab ctab"
+             "rtab cell cell cell cell cell cell cell cell cell cell"
+             "rtab cell cell cell cell cell cell cell cell cell cell"
+             "rtab cell cell cell cell cell cell cell cell cell cell"
+             "rtab cell cell cell cell cell cell cell cell cell cell"
+             "rtab cell cell cell cell cell cell cell cell cell cell"
+             "rtab cell cell cell cell cell cell cell cell cell cell"
+             "rtab cell cell cell cell cell cell cell cell cell cell"
+             "rtab cell cell cell cell cell cell cell cell cell cell"
+             "rtab cell cell cell cell cell cell cell cell cell cell"
+             "rtab cell cell cell cell cell cell cell cell cell cell"
+             "rtab cell cell cell cell cell cell cell cell cell cell"
+             "rtab cell cell cell cell cell cell cell cell cell cell";
+             border: 1px solid black;
+             max-width: 1200px;
+             grid-template-rows: [r-tab-start] 1fr repeat(10, [cell-row-start] 1fr);
+             grid-template-columns: [c-tab-start] 1fr repeat(10, [cell-col-start] 1fr);
+         }
+         .cell {
+             grid-column-start: var(--col-start);
+             grid-column-end: span 1;
+             grid-row-start: var(--row-start);
+             grid-row-end: span 1;
+             height: 50px;
+         }
+         .cell:first-child {
+             grid-column-start: cell-col-start;
+             grid-row-start: cell-row-start;
+         }
+        </style>
+        <script>
+         document.addEventListener('DOMContentLoaded', () => {
+             let numCols = 10;
+             let numRows = 12;
+             let grid = document.getElementById('grid');
+             for(let colNum = 0; colNum < numCols; colNum++){
+                 for(let rowNum = 0; rowNum < numRows; rowNum++){
+                     let el = document.createElement('div');
+                     el.classList.add('cell');
+                     /* el.style.setProperty('--col-start', colNum);
+                      * el.style.setProperty('--row-start', rowNum); */
+                     if(colNum == 0){
+                         el.style.setProperty('--col-start', 'cell-col-start');
+                     } else {
+                         el.style.setProperty('--col-start', `cell-col-start ${colNum + 1}`);
+                     }
+                     if(rowNum == 0){
+                         el.style.setProperty('--row-start', 'cell-row-start');
+                     } else {
+                         el.style.setProperty('--row-start', `cell-row-start ${rowNum + 1}`);
+                     }
+                     var randomColor = Math.floor(Math.random()*16777215).toString(16);
+                     el.style.backgroundColor = `#${randomColor}`;
+                     grid.append(el);
+                     el.textContent = `${colNum}, ${rowNum}`;
+                     }
+             }
+         });
+        </script>
+    </body>
+</html>

--- a/src/CursorElement.js
+++ b/src/CursorElement.js
@@ -1,0 +1,69 @@
+const templateString = `
+<style>
+    :host {
+        box-sizing: border-box;
+        --col-start-name: cell-col-start;
+        --row-start-name: cell-row-start;
+        --col-start: 1;
+        --row-start: 1;
+        grid-column: var(--col-start-name) var(--col-start) / span 1;
+        grid-row: var(--row-start-name) var(--row-start) / span 1;
+        border: 3px solid black;
+    }
+</style>
+`;
+
+class CursorElement extends HTMLElement {
+    constructor(){
+        super();
+        this.template = document.createElement('template');
+        this.template.innerHTML = templateString;
+        this.attachShadow({mode: 'open'});
+        this.shadowRoot.append(
+            this.template.content.cloneNode(true)
+        );
+
+        this.x = 0;
+        this.y = 0;
+        this.relativeX = 0;
+        this.relativeY = 0;
+
+        // Bind instance methods
+        this.updatePosition = this.updatePosition.bind(this);
+    }
+
+    attributeChangedCallback(name, oldVal, newVal){
+        if(name == 'x'){
+            this.x = parseInt(newVal);
+            this.updatePosition();
+        } else if(name === 'y'){
+            this.y= parseInt(newVal);
+            this.updatePosition();
+        } else if(name === 'relative-x'){
+            this.relativeX = parseInt(newVal);
+            this.updatePosition();
+        } else if(this.name === 'relative-y'){
+            this.relativeY = parseInt(newVal);
+            this.updatePosition();
+        }
+    }
+
+    updatePosition(){
+        this.style.setProperty('--col-start', this.x + 1);
+        this.style.setProperty('--row-start', this.y + 1);
+    }
+    
+    static get observedAttributes(){
+        return [
+            'x',
+            'y',
+            'relative-x',
+            'relative-y'
+        ];
+    }
+};
+
+export {
+    CursorElement,
+    CursorElement as default
+};

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -128,6 +128,7 @@ class GridSheet extends HTMLElement {
         this.renderGridTemplate = this.renderGridTemplate.bind(this);
         this.renderRowTabs = this.renderRowTabs.bind(this);
         this.renderColumnTabs = this.renderColumnTabs.bind(this);
+        this.renderGridTemplateAreas = this.renderGridTemplateAreas.bind(this);
         this.dispatchSelectionChanged = this.dispatchSelectionChanged.bind(this);
         this.updateLockedRows = this.updateLockedRows.bind(this);
         this.updateLockedColumns = this.updateLockedColumns.bind(this);
@@ -367,6 +368,48 @@ class GridSheet extends HTMLElement {
         element.style.gridRow = "1 / 2";
         this.shadowRoot.insertBefore(element, this.shadowRoot.querySelector('slot'));
         
+    }
+
+    renderGridTemplateAreas(){
+        let areaLines = [];
+        let totalCols = this.numColumns;
+        if(this.showRowTabs){
+            totalCols += 1;
+        }
+        let totalRows = this.numRows;
+        if(this.showColumnTabs){
+            totalRows += 1;
+        }
+        if(this.showEditorBar){
+            totalRows += 1;
+            var line = `"`;
+            for(let i = 0; i < totalCol; i++){
+                line += `tbar `;
+            }
+            line = `${line.trim()}"`;
+            areaLines.push(line);
+        }
+        if(this.showColumnTabs){
+            var line = `"`;
+            for(let i = 0; i < totalCols; i++){
+                line += `ctab `;
+            }
+            line = `${line.trim()}"`;
+            areaLines.push(line);
+        }
+        // Now do the cell area
+        for(let i = 0; i < this.numRows; i++){
+            var line = `"`;
+            if(this.showRowTabs){
+                line += `rtab `;
+            }
+            for(let j = 0; j < this.numColumns; j++){
+                line += `cell `;
+            }
+            line = `${line.trim()}"`;
+            areaLines.push(line);
+        }
+        return areaLines.join("\n");
     }
 
     dispatchSelectionChanged(){

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -395,17 +395,13 @@ class GridSheet extends HTMLElement {
 
         // Update the selection view element
         let sel = this.shadowRoot.querySelector('sheet-selection');
+        if(this.selector.selectionFrame.isEmpty){
+            sel.hide();
+            return;
+        }
+        sel.show();
         sel.updateFromRelativeFrame(event.detail.frame);
-        let viewOrigin = new Point([
-            this.selector.selectionFrame.origin.x - this.primaryFrame.dataOffset.x,
-            this.selector.selectionFrame.origin.y - this.primaryFrame.dataOffset.y]
-        );
-        let viewCorner = new Point([
-            viewOrigin.x + this.selector.selectionFrame.size.x,
-            viewOrigin.y + this.selector.selectionFrame.size.y
-        ]);
-        let totalViewFrame = new Frame(viewOrigin, viewCorner);
-        sel.updateFromViewFrame(totalViewFrame.intersection(this.primaryFrame));
+        sel.updateFromViewFrame(this.selector.absoluteSelectionFrame);
     }
 
     static get observedAttributes(){

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -395,7 +395,17 @@ class GridSheet extends HTMLElement {
 
         // Update the selection view element
         let sel = this.shadowRoot.querySelector('sheet-selection');
-        sel.updateFromSelector(this.selector);
+        sel.updateFromRelativeFrame(event.detail.frame);
+        let viewOrigin = new Point([
+            this.selector.selectionFrame.origin.x - this.primaryFrame.dataOffset.x,
+            this.selector.selectionFrame.origin.y - this.primaryFrame.dataOffset.y]
+        );
+        let viewCorner = new Point([
+            viewOrigin.x + this.selector.selectionFrame.size.x,
+            viewOrigin.y + this.selector.selectionFrame.size.y
+        ]);
+        let totalViewFrame = new Frame(viewOrigin, viewCorner);
+        sel.updateFromViewFrame(totalViewFrame.intersection(this.primaryFrame));
     }
 
     static get observedAttributes(){

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -7,11 +7,12 @@ import {KeyHandler} from './KeyHandler.js';
 import {ClipboardHandler} from './ClipboardHandler.js';
 import {Frame} from "./Frame.js";
 import {RowTab, ColumnTab} from "./Tab.js";
+import {Selection} from './Selection.js';
 
 // Add any components
 window.customElements.define('row-tab', RowTab);
 window.customElements.define('column-tab', ColumnTab);
-
+window.customElements.define('sheet-selection', Selection);
 
 // Simple grid-based sheet component
 const templateString = `
@@ -88,6 +89,7 @@ const templateString = `
     <input id="edit-area" type="text" disabled="true"/>
 </div>
 <slot></slot>
+<sheet-selection></sheet-selection>
 `;
 
 class GridSheet extends HTMLElement {
@@ -225,7 +227,7 @@ class GridSheet extends HTMLElement {
         // horizontal (column) axis
         let rect = this.getBoundingClientRect();
         let currentCellWidth = this.cellWidth;
-        let newColumns = Math.floor(rect.width / currentCellWidth);
+        let newColumns = Math.floor((rect.width) / currentCellWidth);
         this.setAttribute('columns', newColumns);
         this.render();
     }
@@ -308,7 +310,7 @@ class GridSheet extends HTMLElement {
 
     renderGridTemplate(){
         // Column lines
-        let col = `repeat(${this.numColumns}, [cell-col-start] 1fr)`;
+        let col = `repeat(${this.numColumns}, [cell-col-start] ${this.cellWidth}px)`;
         if(this.showRowTabs){
             col = `[rtab-start] 0.3fr ${col}`;
         }
@@ -328,10 +330,6 @@ class GridSheet extends HTMLElement {
         Array.from(this.shadowRoot.querySelectorAll('row-tab')).forEach(tab => {
             tab.remove();
         });
-        let differential = 0;
-        if(this.showColumnTabs){
-            differential += 1;
-        }
         for(let i = 1; i <= this.numRows; i++){
             let tab = document.createElement('row-tab');
             tab.style.gridColumn = `rtab-start / span 1`;
@@ -346,10 +344,6 @@ class GridSheet extends HTMLElement {
         Array.from(this.shadowRoot.querySelectorAll('column-tab')).forEach(tab => {
             tab.remove();
         });
-        let differential = 0;
-        if(this.showRowTabs){
-            differential += 1;
-        }
         let previousNode = this.shadowRoot.querySelector('slot');
         for(let i = 1; i <= this.numColumns; i++){
             let tab = document.createElement('column-tab');
@@ -398,6 +392,10 @@ class GridSheet extends HTMLElement {
             infoArea.querySelector('span:first-child').innerText = "Selection";
             editArea.value = text;
         }
+
+        // Update the selection view element
+        let sel = this.shadowRoot.querySelector('sheet-selection');
+        sel.updateFromSelector(this.selector);
     }
 
     static get observedAttributes(){

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -7,12 +7,14 @@ import {KeyHandler} from './KeyHandler.js';
 import {ClipboardHandler} from './ClipboardHandler.js';
 import {Frame} from "./Frame.js";
 import {RowTab, ColumnTab} from "./Tab.js";
-import {Selection} from './Selection.js';
+import {SelectionElement} from './SelectionElement.js';
+import {CursorElement} from './CursorElement.js';
 
 // Add any components
 window.customElements.define('row-tab', RowTab);
 window.customElements.define('column-tab', ColumnTab);
-window.customElements.define('sheet-selection', Selection);
+window.customElements.define('sheet-selection', SelectionElement);
+window.customElements.define('sheet-cursor', CursorElement);
 
 // Simple grid-based sheet component
 const templateString = `
@@ -90,6 +92,7 @@ const templateString = `
 </div>
 <slot></slot>
 <sheet-selection></sheet-selection>
+<sheet-cursor id="cursor"></sheet-cursor>
 `;
 
 class GridSheet extends HTMLElement {
@@ -123,6 +126,7 @@ class GridSheet extends HTMLElement {
         this.dataFrame.callback = this.onDataChanged.bind(this);
         this.primaryFrame = new PrimaryFrame(this.dataFrame, [0,0]);
         this.selector = new Selector(this.primaryFrame);
+        this.selector.selectionChangedCallback = this.dispatchSelectionChanged.bind(this);
 
         // Initialize resize observer here.
         // We do this so that any observed attributes will
@@ -392,6 +396,13 @@ class GridSheet extends HTMLElement {
             infoArea.querySelector('span:first-child').innerText = "Selection";
             editArea.value = text;
         }
+
+        // Update cursor
+        let cursorElement = this.shadowRoot.getElementById('cursor');
+        cursorElement.setAttribute('x', this.selector.cursor.x);
+        cursorElement.setAttribute('y', this.selector.cursor.y);
+        cursorElement.setAttribute('relative-x', this.selector.relativeCursor.x);
+        cursorElement.setAttribute('relative-y', this.selector.relativeCursor.y);
 
         // Update the selection view element
         let sel = this.shadowRoot.querySelector('sheet-selection');

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -308,8 +308,6 @@ class GridSheet extends HTMLElement {
         this.primaryFrame.lockColumns(this.numLockedColumns);
         this.primaryFrame.updateCellContents();
         this.selector.primaryFrame = this.primaryFrame;
-        this.selector.drawCursor();
-        this.selector.updateElements();
     }
 
     renderGridTemplate(){

--- a/src/MouseHandler.js
+++ b/src/MouseHandler.js
@@ -50,7 +50,6 @@ class MouseHandler extends Object {
             this.isSelecting = true;
             this.sheet.selector.setCursorToElement(event.target);
             this.sheet.selector.setAnchorToElement(event.target);
-            this.sheet.selector.updateElements();
             this.sheet.dispatchSelectionChanged();
         }
     }
@@ -63,7 +62,6 @@ class MouseHandler extends Object {
         if(event.target.isCell && this.isSelecting){
             this.sheet.selector.setCursorToElement(event.target);
             this.sheet.selector.selectFromAnchorTo(this.sheet.selector.relativeCursor);
-            this.sheet.selector.updateElements();
             this.sheet.dispatchSelectionChanged();
         }
     }
@@ -78,7 +76,6 @@ class MouseHandler extends Object {
         if(event.target.isCell){
             this.sheet.selector.setCursorToElement(event.target);
             this.sheet.selector.setAnchorToElement(event.target);
-            this.sheet.selector.updateElements();
             this.sheet.dispatchSelectionChanged();
         }
     }

--- a/src/PrimaryGridFrame.js
+++ b/src/PrimaryGridFrame.js
@@ -208,6 +208,8 @@ class PrimaryGridFrame extends GridElementsFrame {
                 }
             });
         }
+
+        this.labelElements();
     }
 
     /**

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -1,0 +1,136 @@
+// Experimental Selection web component
+import {Frame} from './Frame.js';
+
+const templateString = `
+<style>
+    :host {
+        --col-start-name: cell-col-start;
+        --row-start-name: cell-row-start;
+        --col-start: 1;
+        --col-end: 1;
+        --row-start: 1;
+        --row-end: 1;
+        grid-column: var(--col-start-name) var(--col-start) / var(--col-start-name) var(--col-end);
+        grid-row: var(--row-start-name) var(--row-start) / var(--row-start-name) var(--row-end);
+        grid-row: var(--row-start-name) var(--row-start) / span var(--row-end);
+        grid-column: var(--col-start-name) var(--col-start) / span var(--col-end);
+        background-color: rgba(0, 0, 100, 0.5);
+    }
+    :host(.empty){
+        display: none;
+    }
+</style>
+`;
+
+class Selection extends HTMLElement {
+    constructor(){
+        super();
+        this.template = document.createElement('template');
+        this.template.innerHTML = templateString;
+        this.attachShadow({mode: 'open'});
+        this.shadowRoot.append(
+            this.template.content.cloneNode(true)
+        );
+        
+        this.viewFrame = new Frame([0,0], [0,0]);
+        this.relativeFrame = new Frame([0,0], [0,0]);
+        
+
+        // Bind instance methods
+        this.updateGridPosition = this.updateGridPosition.bind(this);
+        this.updateFromViewFrame = this.updateFromViewFrame.bind(this);
+        this.updateFromRelativeFrame = this.updateFromRelativeFrame.bind(this);
+        this.updateFromSelector = this.updateFromSelector.bind(this);
+    }
+
+    attributeChangedCallback(name, oldVal, newVal){
+        if(name == 'corner-x'){
+            this.viewFrame.corner.x = parseInt(newVal);
+            this.updateGridPosition();
+        } else if(name == 'corner-y'){
+            this.viewFrame.corner.y = parseInt(newVal);
+            this.updateGridPosition();
+        } else if(name == 'origin-x'){
+            this.viewFrame.origin.x = parseInt(newVal);
+            this.updateGridPosition();
+        } else if(name == 'origin-y'){
+            this.viewFrame.origin.y = parseInt(newVal);
+            this.updateGridPosition();
+        } else if(name == 'data-origin-x'){
+            this.relativeFrame.origin.x = parseInt(newVal);
+            this.updateGridPosition();
+        } else if(name == 'data-origin-y'){
+            this.relativeFrame.origin.y = parseInt(newVal);
+            this.updateGridPosition();
+        } else if(name == 'data-corner-x'){
+            this.relativeFrame.corner.x = parseInt(newVal);
+            this.updateGridPosition();
+        } else if(name == 'data-corner-y'){
+            this.relativeFrame.corner.y = parseInt(newVal);
+            this.updateGridPosition();
+        }
+    }
+
+    updateGridPosition(){
+        // Set the appropriate CSS variables
+        // such that this element will be laid out
+        // in the correct places on a sheet cell grid
+        if(this.viewFrame.isEmpty){
+            this.classList.add('empty');
+            return;
+        }
+        this.classList.remove('empty');
+        let frame = this.viewFrame.intersection(this.relativeFrame);
+        this.style.setProperty('--col-start', frame.origin.x + 1);
+        this.style.setProperty('--col-end', frame.size.x + 1);
+        this.style.setProperty('--row-start', frame.origin.y + 1);
+        this.style.setProperty('--row-end', frame.size.y + 1);
+    }
+
+    updateFromViewFrame(aFrame){
+        this.viewFrame.corner.x = aFrame.corner.x;
+        this.viewFrame.corner.y = aFrame.corner.y;
+        this.viewFrame.origin.x = aFrame.origin.x;
+        this.viewFrame.origin.y= aFrame.origin.y;
+        this.viewFrame.isEmpty = aFrame.isEmpty;
+        this.setAttribute('corner-x', aFrame.corner.x);
+        this.setAttribute('corner-y', aFrame.corner.y);
+        this.setAttribute('origin-x', aFrame.origin.x);
+        this.setAttribute('origin-y', aFrame.origin.y);
+    }
+
+    updateFromRelativeFrame(aFrame){
+        this.relativeFrame.corner.x = aFrame.corner.x;
+        this.relativeFrame.corner.y = aFrame.corner.y;
+        this.relativeFrame.origin.x = aFrame.origin.x;
+        this.relativeFrame.origin.y= aFrame.origin.y;
+        this.relativeFrame.isEmpty = aFrame.isEmpty;
+        this.setAttribute('data-corner-x', aFrame.corner.x);
+        this.setAttribute('data-corner-y', aFrame.corner.y);
+        this.setAttribute('data-origin-x', aFrame.origin.x);
+        this.setAttribute('data-origin-y', aFrame.origin.y);
+    }
+
+    updateFromSelector(aSelector){
+        this.updateFromRelativeFrame(aSelector.primaryFrame.relativeViewFrame);
+        this.updateFromViewFrame(aSelector.selectionFrame);
+    }
+
+    static get observedAttributes(){
+        return [
+            'origin-x',
+            'origin-y',
+            'corner-x',
+            'corner-y',
+            'data-origin-x',
+            'data-origin-y',
+            'data-corner-x',
+            'data-corner-y'
+        ];
+    }
+};
+
+export {
+    Selection,
+    Selection as default
+};

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -44,29 +44,27 @@ class Selection extends HTMLElement {
     }
 
     attributeChangedCallback(name, oldVal, newVal){
+        let needsGridUpdate = true;
         if(name == 'corner-x'){
             this.viewFrame.corner.x = parseInt(newVal);
-            this.updateGridPosition();
         } else if(name == 'corner-y'){
             this.viewFrame.corner.y = parseInt(newVal);
-            this.updateGridPosition();
         } else if(name == 'origin-x'){
             this.viewFrame.origin.x = parseInt(newVal);
-            this.updateGridPosition();
         } else if(name == 'origin-y'){
             this.viewFrame.origin.y = parseInt(newVal);
-            this.updateGridPosition();
         } else if(name == 'data-origin-x'){
             this.relativeFrame.origin.x = parseInt(newVal);
-            this.updateGridPosition();
         } else if(name == 'data-origin-y'){
             this.relativeFrame.origin.y = parseInt(newVal);
-            this.updateGridPosition();
         } else if(name == 'data-corner-x'){
             this.relativeFrame.corner.x = parseInt(newVal);
-            this.updateGridPosition();
         } else if(name == 'data-corner-y'){
             this.relativeFrame.corner.y = parseInt(newVal);
+        } else {
+            needsGridUpdate = false;
+        }
+        if(needsGridUpdate){
             this.updateGridPosition();
         }
     }
@@ -80,7 +78,8 @@ class Selection extends HTMLElement {
             return;
         }
         this.classList.remove('empty');
-        let frame = this.viewFrame.intersection(this.relativeFrame);
+        //let frame = this.viewFrame.intersection(this.relativeFrame);
+        let frame = this.viewFrame;
         this.style.setProperty('--col-start', frame.origin.x + 1);
         this.style.setProperty('--col-end', frame.size.x + 1);
         this.style.setProperty('--row-start', frame.origin.y + 1);

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -15,6 +15,7 @@ const templateString = `
         grid-row: var(--row-start-name) var(--row-start) / span var(--row-end);
         grid-column: var(--col-start-name) var(--col-start) / span var(--col-end);
         background-color: rgba(0, 0, 100, 0.5);
+        pointer-events: none;
     }
     :host(.empty){
         display: none;

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -41,6 +41,8 @@ class Selection extends HTMLElement {
         this.updateFromViewFrame = this.updateFromViewFrame.bind(this);
         this.updateFromRelativeFrame = this.updateFromRelativeFrame.bind(this);
         this.updateFromSelector = this.updateFromSelector.bind(this);
+        this.hide = this.hide.bind(this);
+        this.show = this.show.bind(this);
     }
 
     attributeChangedCallback(name, oldVal, newVal){
@@ -113,6 +115,14 @@ class Selection extends HTMLElement {
     updateFromSelector(aSelector){
         this.updateFromRelativeFrame(aSelector.primaryFrame.relativeViewFrame);
         this.updateFromViewFrame(aSelector.selectionFrame);
+    }
+
+    hide(){
+        this.classList.add('empty');
+    }
+
+    show(){
+        this.classList.remove('empty');
     }
 
     static get observedAttributes(){

--- a/src/SelectionElement.js
+++ b/src/SelectionElement.js
@@ -23,7 +23,7 @@ const templateString = `
 </style>
 `;
 
-class Selection extends HTMLElement {
+class SelectionElement extends HTMLElement {
     constructor(){
         super();
         this.template = document.createElement('template');
@@ -141,6 +141,6 @@ class Selection extends HTMLElement {
 };
 
 export {
-    Selection,
-    Selection as default
+    SelectionElement,
+    SelectionElement as default
 };

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -448,33 +448,33 @@ class Selector {
             let element = this.primaryFrame.elementAt(aPoint);
             let hasSelection = !this.selectionFrame.isEmpty;
 
-            // Clear previous selection borders
-            element.classList.remove(
-                'selection-top-border',
-                'selection-bottom-border',
-                'selection-right-border',
-                'selection-left-border'
-            );
+            // // Clear previous selection borders
+            // element.classList.remove(
+            //     'selection-top-border',
+            //     'selection-bottom-border',
+            //     'selection-right-border',
+            //     'selection-left-border'
+            // );
 
-            // If the relative point is in the selectionFrame,
-            // give the element the appropriate class
-            if(hasSelection && this.selectionFrame.contains(relativePoint)){
-                element.classList.add('in-selection');
-                if(relativePoint.y == this.selectionFrame.top){
-                    element.classList.add('selection-top-border');
-                }
-                if(relativePoint.y == this.selectionFrame.bottom){
-                    element.classList.add('selection-bottom-border');
-                }
-                if(relativePoint.x == this.selectionFrame.left){
-                    element.classList.add('selection-left-border');
-                }
-                if(relativePoint.x == this.selectionFrame.right){
-                    element.classList.add('selection-right-border');
-                }
-            } else {
-                element.classList.remove('in-selection');
-            }
+            // // If the relative point is in the selectionFrame,
+            // // give the element the appropriate class
+            // if(hasSelection && this.selectionFrame.contains(relativePoint)){
+            //     element.classList.add('in-selection');
+            //     if(relativePoint.y == this.selectionFrame.top){
+            //         element.classList.add('selection-top-border');
+            //     }
+            //     if(relativePoint.y == this.selectionFrame.bottom){
+            //         element.classList.add('selection-bottom-border');
+            //     }
+            //     if(relativePoint.x == this.selectionFrame.left){
+            //         element.classList.add('selection-left-border');
+            //     }
+            //     if(relativePoint.x == this.selectionFrame.right){
+            //         element.classList.add('selection-right-border');
+            //     }
+            // } else {
+            //     element.classList.remove('in-selection');
+            // }
 
             // Remove all former cursor or anchor styles
             element.classList.remove(
@@ -602,6 +602,29 @@ class Selector {
      */
     get pageSize(){
         return this.primaryFrame.viewFrame.size;
+    }
+
+    /**
+     * Returns a frame corresponding to actual
+     * points on the PrimaryFrame's view where one
+     * might want to draw a visual indication.
+     * Unlike my `selectionFrame`, this frame won't be
+     * data-relative.
+     */
+    get absoluteSelectionFrame(){
+        let origin = new Point([
+            this.selectionFrame.origin.x - this.primaryFrame.dataOffset.x,
+            this.selectionFrame.origin.y - this.primaryFrame.dataOffset.y
+        ]);
+        let corner = new Point([
+            this.selectionFrame.corner.x - this.primaryFrame.dataOffset.x,
+            this.selectionFrame.corner.y - this.primaryFrame.dataOffset.y
+        ]);
+        let fullView = new Frame(origin, corner);
+        if(this.selectionFrame.isEmpty){
+            fullView.isEmpty = true;
+        }
+        return this.primaryFrame.intersection(fullView);
     }
 };
 

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -64,9 +64,7 @@ class Selector {
         this.selectFromAnchorTo = this.selectFromAnchorTo.bind(this);
         this.setAnchorToElement = this.setAnchorToElement.bind(this);
         this.setCursorToElement = this.setCursorToElement.bind(this);
-        this.updateElements = this.updateElements.bind(this);
-        this.drawAnchor = this.drawAnchor.bind(this);
-        this.drawCursor = this.drawCursor.bind(this);
+        this.triggerCallback = this.triggerCallback.bind(this);
     }
 
     /**
@@ -107,7 +105,7 @@ class Selector {
             this.anchor = this.relativeCursor;
         }
 
-        this.updateElements();
+        this.triggerCallback();
     }
 
     /**
@@ -164,7 +162,7 @@ class Selector {
             this.anchor = this.relativeCursor;
         }
 
-        this.updateElements();
+        this.triggerCallback();
     }
 
     /**
@@ -219,7 +217,7 @@ class Selector {
             this.anchor = this.relativeCursor;
         }
 
-        this.updateElements();
+        this.triggerCallback();
     }
 
     /**
@@ -258,7 +256,7 @@ class Selector {
             this.anchor = this.relativeCursor;
         }
 
-        this.updateElements();
+        this.triggerCallback();
     }
 
     /**
@@ -391,46 +389,6 @@ class Selector {
     }
 
     /**
-     * I find the td element at the current
-     * cursor location on the primaryFrame
-     * and add the appropriate CSS class to it.
-     * If there is a cached previousCursor, I
-     * remove the CSS class from it.
-     */
-    drawCursor(withAnchor=false){
-        // let element = this.primaryFrame.elementAt(this.cursor);
-        // element.classList.add('selector-cursor');
-        // if(withAnchor){
-        //     element.classList.add('selector-anchor');
-        // }
-        // if(this.prevCursorEl && this.prevCursorEl != element){
-        //     this.prevCursorEl.classList.remove('selector-cursor');
-        // }
-        // this.prevCursorEl = element;
-    }
-
-    /**
-     * I find the td element at the current
-     * anchor location on the primaryFrame
-     * and add the appropriate CSS class to it.
-     * Note that if my anchor and cursor points
-     * are equivalent, I only call `drawCursor`
-     */
-    drawAnchor(){
-        if(this.anchor.equals(this.relativeCursor)){
-            return this.drawCursor(true);
-        }
-        let absoluteAnchor = new Point([
-            this.anchor.x - this.primaryFrame.dataOffset.x,
-            this.anchor.y - this.primaryFrame.dataOffset.y
-        ]);
-        if(this.primaryFrame.contains(absoluteAnchor)){
-            let element = this.primaryFrame.elementAt(absoluteAnchor);
-            element.classList.add('selector-anchor');
-        }
-    }
-
-    /**
      * I loop through each of the Points in my
      * underlying primaryFrame and add/remove
      * CSS classes to each corresponding td element
@@ -442,58 +400,12 @@ class Selector {
      *   corresponding data-relative Point is
      *   within the current selectionFrame
      */
-    updateElements(){
+    triggerCallback(){
         // Instead, trigger a callback on the consumer with updated
         // selection and/or cursor information
         if(this.selectionChangedCallback){
             this.selectionChangedCallback();
         }
-        this.primaryFrame.forEachPoint(aPoint => {
-            let relativePoint = this.primaryFrame.relativePointAt(aPoint);
-            let element = this.primaryFrame.elementAt(aPoint);
-            let hasSelection = !this.selectionFrame.isEmpty;
-
-            // // Clear previous selection borders
-            // element.classList.remove(
-            //     'selection-top-border',
-            //     'selection-bottom-border',
-            //     'selection-right-border',
-            //     'selection-left-border'
-            // );
-
-            // // If the relative point is in the selectionFrame,
-            // // give the element the appropriate class
-            // if(hasSelection && this.selectionFrame.contains(relativePoint)){
-            //     element.classList.add('in-selection');
-            //     if(relativePoint.y == this.selectionFrame.top){
-            //         element.classList.add('selection-top-border');
-            //     }
-            //     if(relativePoint.y == this.selectionFrame.bottom){
-            //         element.classList.add('selection-bottom-border');
-            //     }
-            //     if(relativePoint.x == this.selectionFrame.left){
-            //         element.classList.add('selection-left-border');
-            //     }
-            //     if(relativePoint.x == this.selectionFrame.right){
-            //         element.classList.add('selection-right-border');
-            //     }
-            // } else {
-            //     element.classList.remove('in-selection');
-            // }
-
-            // Remove all former cursor or anchor styles
-            element.classList.remove(
-                'selector-anchor',
-                'selector-cursor'
-            );
-        });
-
-        // Give the cursor the correct cursor
-        // class
-        this.drawCursor();
-
-        // Draw the anchor element
-        this.drawAnchor();
     }
 
     /**

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -398,15 +398,15 @@ class Selector {
      * remove the CSS class from it.
      */
     drawCursor(withAnchor=false){
-        let element = this.primaryFrame.elementAt(this.cursor);
-        element.classList.add('selector-cursor');
-        if(withAnchor){
-            element.classList.add('selector-anchor');
-        }
-        if(this.prevCursorEl && this.prevCursorEl != element){
-            this.prevCursorEl.classList.remove('selector-cursor');
-        }
-        this.prevCursorEl = element;
+        // let element = this.primaryFrame.elementAt(this.cursor);
+        // element.classList.add('selector-cursor');
+        // if(withAnchor){
+        //     element.classList.add('selector-anchor');
+        // }
+        // if(this.prevCursorEl && this.prevCursorEl != element){
+        //     this.prevCursorEl.classList.remove('selector-cursor');
+        // }
+        // this.prevCursorEl = element;
     }
 
     /**
@@ -443,6 +443,11 @@ class Selector {
      *   within the current selectionFrame
      */
     updateElements(){
+        // Instead, trigger a callback on the consumer with updated
+        // selection and/or cursor information
+        if(this.selectionChangedCallback){
+            this.selectionChangedCallback();
+        }
         this.primaryFrame.forEachPoint(aPoint => {
             let relativePoint = this.primaryFrame.relativePointAt(aPoint);
             let element = this.primaryFrame.elementAt(aPoint);

--- a/src/SheetCell.js
+++ b/src/SheetCell.js
@@ -7,7 +7,10 @@
  */
 const templateString = `
 <style>
-
+    :host {
+        --col-start-name: cell-col-start;
+        --row-start-name: cell-row-start;
+    }
 </style>
 <slot></slot>
 `;
@@ -23,19 +26,77 @@ class SheetCell extends HTMLElement {
         );
 
         this.isCell = true;
+        this.row = 0;
+        this.column = 0;
+        this.relativeRow = 0;
+        this.relativeColumn = 0;
 
+        // Bind methods
+        this.updateRow = this.updateRow.bind(this);
+        this.updateColumn = this.updateColumn.bind(this);
     }
 
     connectedCallback(){
         if(this.isConnected){
 
             // Event listeners
-     
+
+            
         }
     }
 
     disconnectedCallback(){
      
+    }
+
+    attributeChangedCallback(name, oldVal, newVal){
+        if(name == 'data-x'){
+            this.updateColumn(newVal);
+        } else if(name == 'data-relative-x'){
+            this.updateColumn(newVal, true);
+        } else if(name == 'data-y'){
+            this.updateRow(newVal);
+        } else if(name == 'data-relative-y'){
+            this.updateRow(newVal, true);
+        }
+    }
+
+    updateRow(strVal, isRelative=false){
+        let num = parseInt(strVal);
+        if(num < 0){
+            return;
+        }
+        if (isRelative) {
+            this.relativeRow = num;
+        } else {
+            this.row = num;
+            let suffix = num == 0 ? `` : ` ${num + 1}`;
+            this.style.setProperty("--row-start", `var(--row-start-name)${suffix}`);
+        }
+    }
+
+    updateColumn(strVal, isRelative=false){
+        let num = parseInt(strVal);
+        if(num < 0){
+            return;
+        }
+        if(isRelative){
+            this.relativeColumn = num;
+        } else {
+            this.column = num;
+            let suffix = num == 0 ? `` : ` ${num + 1}`;
+            
+            this.style.setProperty("--col-start", `var(--col-start-name)${suffix}`);
+        }
+    }
+
+    static get observedAttributes(){
+        return [
+            'data-x',
+            'data-y',
+            'data-relative-x',
+            'data-relative-y'
+        ];
     }
 };
 

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -1,0 +1,27 @@
+class RowReference extends Object {
+    constructor(index, sheet, label){
+        this.index = index;
+        this.sheet = sheet;
+        this.label = label;
+    }
+};
+
+
+const rowTabTemplateString = `
+<style>
+    :host {
+        border: 1px solid green;
+        background-color: blue;
+    }
+</style>
+`;
+
+class RowTab extends HTMLElement {
+    constructor(){
+        super();
+    }
+};
+
+export {
+    RowTab
+};

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -10,8 +10,11 @@ class RowReference extends Object {
 const rowTabTemplateString = `
 <style>
     :host {
-        border: 1px solid green;
-        background-color: blue;
+        border: 1px solid rgba(150, 150, 150, 0.4);
+        border-bottom: none;
+        box-sizing: border-box;
+        border-top-left-radius: 5px;
+        border-bottom-left-radius: 5px;
     }
 </style>
 `;
@@ -19,9 +22,22 @@ const rowTabTemplateString = `
 class RowTab extends HTMLElement {
     constructor(){
         super();
+        this.template = document.createElement('template');
+        this.template.innerHTML = rowTabTemplateString;
+        this.attachShadow({mode: 'open'});
+        this.shadowRoot.append(
+            this.template.content.cloneNode(true)
+        );
+    }
+};
+
+class ColumnTab extends HTMLElement {
+    constructor(){
+        super();
     }
 };
 
 export {
-    RowTab
+    RowTab,
+    ColumnTab
 };

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -6,6 +6,10 @@ class RowReference extends Object {
     }
 };
 
+const letters = [
+    "A","B","C","D","E","F","G","H"
+];
+
 
 const rowTabTemplateString = `
 <style>
@@ -15,8 +19,16 @@ const rowTabTemplateString = `
         box-sizing: border-box;
         border-top-left-radius: 5px;
         border-bottom-left-radius: 5px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    :host(:last-child){
+        border-bottom: 1px solid rgba(150, 150, 150, 0.4);
     }
 </style>
+<span id="label">
+</span>
 `;
 
 class RowTab extends HTMLElement {
@@ -28,12 +40,100 @@ class RowTab extends HTMLElement {
         this.shadowRoot.append(
             this.template.content.cloneNode(true)
         );
+
+        this.row = 0;
+        this.relativeRow = 0;
+
+        // Bind instance methods
+        this.setLabel = this.setLabel.bind(this);
+    }
+
+    attributeChangedCallback(name, oldVal, newVal){
+        if(name == 'data-y'){
+            this.row = parseInt(newVal);
+        } else if(name == 'data-relative-y'){
+            this.relativeRow = parseInt(newVal);
+            this.setLabel(this.relativeRow);
+        }
+    }
+
+    setLabel(num){
+        this.shadowRoot.getElementById('label').innerText = num.toString();
+    }
+
+    static get observedAttributes(){
+        return [
+            'data-y',
+            'data-relative-y'
+        ];
     }
 };
 
+
+const columnTabTemplateString = `
+<style>
+    :host {
+        border: 1px solid rgba(150, 150, 150, 0.4);
+        border-bottom: none;
+        box-sizing: border-box;
+        border-top-left-radius: 5px;
+        border-bottom-left-radius: 5px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+</style>
+<span id="label"></span>
+`;
 class ColumnTab extends HTMLElement {
     constructor(){
         super();
+        this.template = document.createElement('template');
+        this.template.innerHTML = columnTabTemplateString;
+        this.attachShadow({mode: 'open'});
+        this.shadowRoot.append(
+            this.template.content.cloneNode(true)
+        );
+
+        this.column = 0;
+        this.relativeColumn = 0;
+
+        // Bind instance methods
+        this.setLabel = this.setLabel.bind(this);
+    }
+
+    attributeChangedCallback(name, oldVal, newVal){
+        if(name == 'data-x'){
+            this.column = parseInt(newVal);
+        } else if(name == 'data-relative-x'){
+            this.relativeColumn = parseInt(newVal);
+            this.setLabel(this.relativeColumn);
+        }
+    }
+
+    setLabel(num){
+        let index = num - 1;
+        let remainder, diviz;
+        let label = "";
+        if(index < letters.length){
+            label = letters[index];
+        } else {
+            diviz = Math.floor(index / letters.length);
+            remainder = index % letters.length;
+            let letter = letters[remainder];
+            let times = diviz + 1;
+            for(let i = 0; i < times; i++){
+                label += letter;
+            }
+        }
+        this.shadowRoot.getElementById('label').innerText = label;
+    }
+
+    static get observedAttributes(){
+        return [
+            'data-x',
+            'data-relative-x'
+        ];
     }
 };
 


### PR DESCRIPTION
## What ##
This PR adjusts the newer grid-based sheet framework to have or use the following:
1. Locked rows and columns now display and work with navigation;
2. Optional row/column tabs for display (and interaction down the road)
3. Grid-based selection element
4. Grid-based cursor element

## Implementation ##
### Locked Rows and Columns ###
Consumers can now set the number of locked rows an columns directly on the sheet element using the `lockedrows=` and `lockedcolumns=` HTML attributes. The sheet will adjust accordingly.
  
Note that unlike the cursor and selection (see below), the locked rows/column frame styling is not yet implemented as a Grid, but rather classes on the underlying grid elements. 
  
### Column and Row Tabs ###
We introduce here two new elements called `<row-tab>` and `<column-tab>` (both in `Tab.js`). These are custom elements with minimal functionality for the moment, but in the future we can use them to manage custom column/row settings or styling, as well as other traditional Mouse events like selecting a whole row, etc.
  
### Grid-Based Selection ###
One important aspect of the CSS Grid mechanism is that you can display multiple elements overlapping through the same grid areas -- they will simply display on top (or below, based on z-index etc) of each other wherever they intersect according to their grid coordinates. Because of this, it makes more sense to have a specific `<sheet-selection>` element laid out on the grid in the appropriate place, rather than to style specific borders of the underlying elements as we were doing before.
  
Therefore, we introduce the `<sheet-selection>` element into the sheet's shadow dom (at `SelectionElement.js`). The SelectionElement has attributes for its origin/corner points, as well as any data-relative origin and corner points. Updating these HTML attributes changes where the selection element displays itself on the underlying grid. The actual translation from point information to grid-line locations is handled via the use of CSS variables that are initially defined in the shadow dom, then later updated inline on attribute changed actions.
  
Using SelectionElement as the "view" for selections removes all styling related code from the Selector.
  
### Grid-Based Cursor ###
As with the new SelectionElement described above, we also introduce a new `<sheet-cursor>` element to the sheet's shadow dom (in `CursorElement.js`). This operates similarly to the SelectionElement, in that it has attributes for the view-based x and y coordinates, as well as the data-relative x and y coordinates. Again, it uses CSS variables to determine how to translate point information into locations on the layout grid.
  
### Communicating Changes ###
All cursor and selection updates are communicated to the sheet first via a callback from the Selector, and then via a CustomEvent dispatch called `selection-changed`. All updates to the `<sheet-selection>` and `<sheet-cursor>` happen in the default handler for this event. This infratructure allows us to potentially add multiple selection areas for display in the future, if needed for some UI reason.
  
## Testing ##
Run a local server (like `python3 -m http.server`) at the root of the directory then load [http://localhost:8000/examples/](http://localhost:8000/examples/)