### PR TITLE
Tab Improvements

### DIFF
--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -105,6 +105,11 @@ column-tab[locked="true"] {
     background-color: rgba(240, 240, 240, 0.8);
 }
 
+row-tab,
+column-tab {
+    font-family: monospace;
+}
+
 </style>
 <div id="edit-bar" style="grid-column: 1 / -1; grid-row: span 1;">
     <div id="info-area"><span>Cursor</span><span>&rarr;</span></div>
@@ -137,6 +142,11 @@ class GridSheet extends HTMLElement {
         this.numColumns = 1;
         this.showRowTabs = true;
         this.showColumnTabs = true;
+
+        // Default column and row
+        // customizations
+        this.customColumns = {};
+        this.customRows = {};
 
         // Set up the internal frames
         this.dataFrame = new DataFrame([0,0], [1000,1000]);
@@ -401,6 +411,25 @@ class GridSheet extends HTMLElement {
             if(i < this.numLockedRows){
                 tab.setAttribute('locked', true);
             }
+
+            // Add event listener for clicking to
+            // select whole row
+            tab.addEventListener('click', (event) => {
+                if(event.button == 0){
+                    let targetPoint = new Point([0, event.target.relativeRow]);
+                    this.selector.anchor = targetPoint;
+                    let endPoint = new Point([
+                        this.dataFrame.right,
+                        targetPoint.y
+                    ]);
+                    this.selector.selectFromAnchorTo(endPoint);
+                    this.selector.cursor = new Point([
+                        this.selector.cursor.x,
+                        tab.row
+                    ]);
+                    this.selector.triggerCallback();
+                }
+            });
         }
     }
 
@@ -423,6 +452,25 @@ class GridSheet extends HTMLElement {
             if(i < this.numLockedColumns){
                 tab.setAttribute('locked', true);
             }
+
+            // Add event listener for clicking to
+            // select the whole column
+            tab.addEventListener('click', (event) => {
+                if(event.button === 0){
+                    let targetPoint = new Point([event.target.relativeColumn, 0]);
+                    this.selector.anchor = targetPoint;
+                    let endPoint = new Point([
+                        targetPoint.x,
+                        this.dataFrame.bottom
+                    ]);
+                    this.selector.selectFromAnchorTo(endPoint);
+                    this.selector.cursor = new Point([
+                        tab.column,
+                        this.selector.cursor.y
+                    ]);
+                    this.selector.triggerCallback();
+                }
+            });
         }
     }
 

--- a/src/LockedSelectionElement.js
+++ b/src/LockedSelectionElement.js
@@ -1,0 +1,36 @@
+import {SelectionElement} from "./SelectionElement.js";
+
+class LockedRowsElement extends SelectionElement {
+    constructor(){
+        super();
+    }
+
+    updateFromSelector(aSelector){
+        this.updateFromRelativeFrame(
+            aSelector.primaryFrame.relativeLockedRowsFrame
+        );
+        this.updateFromViewFrame(
+            aSelector.primaryFrame.lockedRowsFrame
+        );
+    }
+}
+
+class LockedColumnsElement extends SelectionElement {
+    constructor(){
+        super();
+    }
+
+    updateFromSelector(aSelector){
+        this.updateFromRelativeFrame(
+            aSelector.primaryFrame.relativeLockedColumnsFrame
+        );
+        this.updateFromViewFrame(
+            aSelector.primaryFrame.lockedColumnsFrame
+        );
+    }
+}
+
+export {
+    LockedRowsElement,
+    LockedColumnsElement
+};

--- a/src/PrimaryGridFrame.js
+++ b/src/PrimaryGridFrame.js
@@ -154,21 +154,6 @@ class PrimaryGridFrame extends GridElementsFrame {
      */
     labelElements(){
         let classesToClear = ['in-locked-row', 'in-locked-column', 'view-cell'];
-        // Begin with columns
-        this.lockedColumnsFrame.forEachPoint(aPoint => {
-            let el = this.elementAt(aPoint);
-            if (el !== null) {
-                el.classList.remove(...classesToClear);
-                el.classList.add('in-locked-column');
-            }
-        });
-        this.lockedRowsFrame.forEachPoint(aPoint => {
-            let el = this.elementAt(aPoint);
-            if (el !== null) {
-                el.classList.remove(...classesToClear);
-                el.classList.add('in-locked-row');
-            }
-        });
         this.viewFrame.forEachPoint(aPoint => {
             let el = this.elementAt(aPoint);
             if (el !== null) {

--- a/src/SelectionElement.js
+++ b/src/SelectionElement.js
@@ -90,6 +90,10 @@ class SelectionElement extends HTMLElement {
     }
 
     updateFromViewFrame(aFrame){
+        if(aFrame === null){
+            this.viewFrame.isEmpty = true;
+            return;
+        }
         this.viewFrame.corner.x = aFrame.corner.x;
         this.viewFrame.corner.y = aFrame.corner.y;
         this.viewFrame.origin.x = aFrame.origin.x;
@@ -102,6 +106,10 @@ class SelectionElement extends HTMLElement {
     }
 
     updateFromRelativeFrame(aFrame){
+        if(aFrame === null){
+            this.relativeFrame.isEmpty = true;
+            return;
+        }
         this.relativeFrame.corner.x = aFrame.corner.x;
         this.relativeFrame.corner.y = aFrame.corner.y;
         this.relativeFrame.origin.x = aFrame.origin.x;

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -7,7 +7,10 @@ class RowReference extends Object {
 };
 
 const letters = [
-    "A","B","C","D","E","F","G","H"
+    "A","B","C","D","E","F","G","H",
+    "I","J","K","L","M","N","O","P",
+    "Q","R","S","T","U","V","W","X",
+    "Y","Z"
 ];
 
 
@@ -64,7 +67,8 @@ class RowTab extends HTMLElement {
     static get observedAttributes(){
         return [
             'data-y',
-            'data-relative-y'
+            'data-relative-y',
+            'highlighted'
         ];
     }
 };

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -17,6 +17,7 @@ const letters = [
 const rowTabTemplateString = `
 <style>
     :host {
+        position: relative;
         border: 1px solid rgba(150, 150, 150, 0.4);
         border-bottom: none;
         box-sizing: border-box;
@@ -36,9 +37,25 @@ const rowTabTemplateString = `
     :host(:hover){
         cursor: pointer;
     }
+    .adjuster {
+        display: block;
+        position: absolute;
+        width: 100%;
+        height: 8px;
+        left: 0;
+    }
+    .adjuster:hover {
+        cursor: row-resize;
+        background-color: rgba(100, 100, 100, 0.5);
+    }
+    #bottom-adjuster {
+        bottom: -4px;
+    }
+   
 </style>
 <span id="label">
 </span>
+<div id="bottom-adjuster" class="adjuster"></div>
 `;
 
 class RowTab extends HTMLElement {
@@ -54,8 +71,29 @@ class RowTab extends HTMLElement {
         this.row = 0;
         this.relativeRow = 0;
 
+        // a Cached version of the measurment
+        this._cachedHeight = null;
+        this._cachedMouseY = 0;
+
         // Bind instance methods
         this.setLabel = this.setLabel.bind(this);
+        this.onAdjusterMouseDown = this.onAdjusterMouseDown.bind(this);
+        this.onAdjusterMouseUp = this.onAdjusterMouseUp.bind(this);
+        this.onAdjusterMouseMove = this.onAdjusterMouseMove.bind(this);
+        this.onAdjusterClick = this.onAdjusterClick.bind(this);
+    }
+
+    connectedCallback(){
+        if(this.isConnected){
+            // Event listeners
+            let adjuster = this.shadowRoot.querySelector('.adjuster');
+            adjuster.addEventListener('mousedown', this.onAdjusterMouseDown);
+        }
+    }
+
+    disconnectedCallback(){
+        let adjuster = this.shadowRoot.querySelector('.adjuster');
+        adjuster.removeEventListener('mousedown', this.onAdjusterMouseDown);
     }
 
     attributeChangedCallback(name, oldVal, newVal){
@@ -65,6 +103,36 @@ class RowTab extends HTMLElement {
             this.relativeRow = parseInt(newVal);
             this.setLabel(this.relativeRow);
         }
+    }
+
+    onAdjusterMouseDown(event){
+        document.addEventListener('mousemove', this.onAdjusterMouseMove);
+        document.addEventListener('mouseup', this.onAdjusterMouseUp);
+        this.addEventListener('click', this.onAdjusterClick);
+        // Get the initial measurment for the width of the column
+        this._cachedHeight = this.getBoundingClientRect().height;
+        this._cachedMouseY = event.clientY;
+    }
+
+    onAdjusterMouseUp(event){
+        document.removeEventListener('mousemove', this.onAdjusterMouseMove);
+        document.removeEventListener('mouseup', this.onAdjusterMouseUp);
+        event.stopPropagation();
+    }
+
+    onAdjusterMouseMove(event){
+        let diff = event.clientY - this._cachedMouseY;
+        let newEvent = new CustomEvent('row-adjustment', {
+            detail: {
+                newHeight: (this._cachedHeight + diff)
+            }
+        });
+        this.dispatchEvent(newEvent);
+    }
+
+    onAdjusterClick(event){
+        event.stopPropagation();
+        this.removeEventListener('click', this.onAdjusterClick);
     }
 
     setLabel(num){
@@ -84,6 +152,7 @@ class RowTab extends HTMLElement {
 const columnTabTemplateString = `
 <style>
     :host {
+        position: relative;
         border: 1px solid rgba(150, 150, 150, 0.4);
         border-bottom: none;
         box-sizing: border-box;
@@ -100,8 +169,25 @@ const columnTabTemplateString = `
     :host(:hover){
         cursor: pointer;
     }
+
+    .adjuster {
+        display: block;
+        position: absolute;
+        width: 30px;
+        height: 100%;
+        top: 0;
+    }
+    .adjuster:hover {
+        cursor: col-resize;
+        background-color: rgba(100, 100, 100, 0.5);
+    }
+    #right-adjuster {
+        right: -15px;
+    }
+    
 </style>
 <span id="label"></span>
+<div id="right-adjuster" class="adjuster"></div>
 `;
 class ColumnTab extends HTMLElement {
     constructor(){
@@ -116,8 +202,29 @@ class ColumnTab extends HTMLElement {
         this.column = 0;
         this.relativeColumn = 0;
 
+        // a Cached version of the measurment
+        this._cachedWidth = null;
+        this._cachedMouseX = 0;
+
         // Bind instance methods
         this.setLabel = this.setLabel.bind(this);
+        this.onAdjusterMouseDown = this.onAdjusterMouseDown.bind(this);
+        this.onAdjusterMouseUp = this.onAdjusterMouseUp.bind(this);
+        this.onAdjusterMouseMove = this.onAdjusterMouseMove.bind(this);
+        this.onAdjusterClick = this.onAdjusterClick.bind(this);
+    }
+
+    connectedCallback(){
+        if(this.isConnected){
+            // Event listeners
+            let rightAdjuster = this.shadowRoot.getElementById('right-adjuster');
+            rightAdjuster.addEventListener('mousedown', this.onAdjusterMouseDown);
+        }
+    }
+
+    disconnectedCallback(){
+        let rightAdjuster = this.shadowRoot.getElementById('right-adjuster');
+        rightAdjuster.removeEventListener('mousedown', this.onAdjusterMouseDown);
     }
 
     attributeChangedCallback(name, oldVal, newVal){
@@ -145,6 +252,36 @@ class ColumnTab extends HTMLElement {
             }
         }
         this.shadowRoot.getElementById('label').innerText = label;
+    }
+
+    onAdjusterMouseDown(event){
+        document.addEventListener('mousemove', this.onAdjusterMouseMove);
+        document.addEventListener('mouseup', this.onAdjusterMouseUp);
+        this.addEventListener('click', this.onAdjusterClick);
+        // Get the initial measurment for the width of the column
+        this._cachedWidth = this.getBoundingClientRect().width;
+        this._cachedMouseX = event.clientX;
+    }
+
+    onAdjusterMouseMove(event){
+        let diff = event.clientX - this._cachedMouseX;
+        let newEvent = new CustomEvent('column-adjustment', {
+            detail: {
+                newWidth: (this._cachedWidth + diff)
+            }
+        });
+        this.dispatchEvent(newEvent);
+    }
+
+    onAdjusterMouseUp(event){
+        document.removeEventListener('mousemove', this.onAdjusterMouseMove);
+        document.removeEventListener('mouseup', this.onAdjusterMouseUp);
+        event.stopPropagation();
+    }
+
+    onAdjusterClick(event){
+        event.stopPropagation();
+        this.removeEventListener('click', this.onAdjusterClick);
     }
 
     static get observedAttributes(){

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -33,6 +33,9 @@ const rowTabTemplateString = `
     :host([highlighted]){
         background-color: var(--tracking-highlight-color);
     }
+    :host(:hover){
+        cursor: pointer;
+    }
 </style>
 <span id="label">
 </span>
@@ -93,6 +96,9 @@ const columnTabTemplateString = `
     }
     :host([highlighted]){
         background-color: var(--tracking-highlight-color);
+    }
+    :host(:hover){
+        cursor: pointer;
     }
 </style>
 <span id="label"></span>

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -25,9 +25,13 @@ const rowTabTemplateString = `
         display: flex;
         align-items: center;
         justify-content: center;
+        --tracking-highlight-color: rgba(240, 240, 240, 0.8);
     }
     :host(:last-child){
         border-bottom: 1px solid rgba(150, 150, 150, 0.4);
+    }
+    :host([highlighted]){
+        background-color: var(--tracking-highlight-color);
     }
 </style>
 <span id="label">
@@ -61,7 +65,7 @@ class RowTab extends HTMLElement {
     }
 
     setLabel(num){
-        this.shadowRoot.getElementById('label').innerText = num.toString();
+        this.shadowRoot.getElementById('label').innerText = (num + 1).toString();
     }
 
     static get observedAttributes(){
@@ -85,6 +89,10 @@ const columnTabTemplateString = `
         display: flex;
         align-items: center;
         justify-content: center;
+        --tracking-highlight-color: rgba(240, 240, 240, 0.8);
+    }
+    :host([highlighted]){
+        background-color: var(--tracking-highlight-color);
     }
 </style>
 <span id="label"></span>
@@ -111,7 +119,7 @@ class ColumnTab extends HTMLElement {
             this.column = parseInt(newVal);
         } else if(name == 'data-relative-x'){
             this.relativeColumn = parseInt(newVal);
-            this.setLabel(this.relativeColumn);
+            this.setLabel(this.relativeColumn + 1);
         }
     }
 


### PR DESCRIPTION
## What ##
This PR implements the following tab-related features:
  
1. Row and Column tabs now update their labels during shift events;
2. The corresponding Column/Row tab will now highlight (for now display at a darker color) when the Cursor is in the corresponding Column/Row;
3. As with 2, Rows and Columns that intersect with the current selection will have their tabs highlighted;
4. Locked Rows/Columns are now displayed in grid fashion using custom elements that span the grid;
5. Clicking on a Column or Row tab with automatically select that whole column or row.
6. Adjustable column width/row heights via Tabs
  
## Implementation Notes ##
### New `sheet-view-shifted` event ###
The GridSheet now dispatches a new custom event called `sheet-view-shifted` on itself whenever the PrimaryFrame shifts during the process of selection navigation.
  
The first consumer of this event is the GridSheet itself, which uses the handler to update the numbers and letters in the row and column tabs.
  
### Column and Row Tab `highlighted` attribute ###
Tabs can now be styled by setting or removing the `highlighted=` attribute on their elements. This is what it set in order to track cursor and selection positions when higlighting corresponding tabs. The default styling is set by the CSS variable `--tracking-highlight-color`.
  
### `<locked-rows>` and `<locked-columns>` selection elements ###
In order to fold styling of areas of locked rows and columns, we introduce two new elements called `<locked-rows>` and `<locked-columns>` in the GridSheet's shadow dom. Each of these is actually just a subclass of `SelectionElement` with a specific override on `updateFromSelector()`. These elements are updated during the GridSheets handler for the `selection-updated` event.
  
### Adjustable Column Widths and Row Heights ###
The GridSheet now maintains a dictionary of "custom" column widths and heights for each data-relative row or column that sets its own custom property via mouse events. These values are now looked up during `renderGridTemplate()`, which sets up the grid lines for the rows and columns using inline CSS.
  
Within the `RowTab` and `ColumnTab` elements, there is an absolutely positioned element in the shadow dom that handles hovering and mouse events for resizing. When an appropriate movement has taken place, a new custom event (either `row-adjustment` or `column-adjustment`) is dispatched and handled by GridSheet, who uses the event's detail to set new measurement and calls `renderGridTemplate()` with updated values.
  
The advantage of this approach is that when we shift views, it is the data-relative column/row adjustments that are remembered and not the strict view columns and rows. 
  
To try this out, hover near the right end / bottom end of a column / row tab to highlight the adjuster, then click-hold and move it.