### PR TITLE
Tab Shift Selection

### DIFF
--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -439,47 +439,10 @@ class GridSheet extends HTMLElement {
             if(i < this.numLockedRows){
                 tab.setAttribute('locked', true);
             }
-
-            // Add event listener for clicking to
-            // select whole row
-            // tab.addEventListener('click', (event) => {
-            //     if(event.button == 0){
-            //         let targetPoint = new Point([0, event.target.relativeRow]);
-            //         this.selector.anchor = targetPoint;
-            //         let endPoint = new Point([
-            //             this.dataFrame.right,
-            //             targetPoint.y
-            //         ]);
-            //         this.selector.selectFromAnchorTo(endPoint);
-            //         this.selector.cursor = new Point([
-            //             this.selector.cursor.x,
-            //             tab.row
-            //         ]);
-            //         this.selector.triggerCallback();
-            //     }
-            // });
             tab.addEventListener('click', this.onTabClick.bind(this));
 
             // Add event listener for row adjustment
             tab.addEventListener('row-adjustment', this.handleRowAdjustment);
-        }
-    }
-
-    onTabClick(event){
-        if(event.target.isRowTab && event.button === 0){
-            let rowOrigin = new Point([0, event.target.relativeRow]);
-            let rowCorner = new Point([this.dataFrame.right, event.target.relativeRow]);
-            let rowRelativeFrame = new Frame(rowOrigin, rowCorner);
-            if(event.shiftKey){
-                
-            } else {
-                this.selector.anchor = rowOrigin;
-            }
-            this.selector.selectFromAnchorTo(rowCorner);
-            // Update the cursor?
-            this.selector.triggerCallback();
-        } else if(event.target.isColumnTab && event.button === 0){
-            
         }
     }
 
@@ -503,27 +466,72 @@ class GridSheet extends HTMLElement {
                 tab.setAttribute('locked', true);
             }
 
-            // Add event listener for clicking to
-            // select the whole column
-            tab.addEventListener('click', (event) => {
-                if(event.button === 0){
-                    let targetPoint = new Point([event.target.relativeColumn, 0]);
-                    this.selector.anchor = targetPoint;
-                    let endPoint = new Point([
-                        targetPoint.x,
-                        this.dataFrame.bottom
-                    ]);
-                    this.selector.selectFromAnchorTo(endPoint);
-                    this.selector.cursor = new Point([
-                        tab.column,
-                        this.selector.cursor.y
-                    ]);
-                    this.selector.triggerCallback();
-                }
-            });
+            tab.addEventListener('click', this.onTabClick.bind(this));
 
             // Add event listener for width adjustment
             tab.addEventListener('column-adjustment', this.handleColumnAdjustment);
+        }
+    }
+
+    onTabClick(event){
+        if(event.target.isRowTab && event.button === 0){
+            let rowOrigin = new Point([0, event.target.relativeRow]);
+            let rowCorner = new Point([this.dataFrame.right, event.target.relativeRow]);
+            this.selector.anchor = rowCorner;
+            if(event.shiftKey){
+                if(rowCorner.y > this.selector.selectionFrame.origin.y){
+                    // The new row is "below" the current selection.
+                    // Set anchor to top right corner of what will be
+                    // the union frame.
+                    this.selector.anchor = new Point([
+                        this.dataFrame.right,
+                        this.selector.selectionFrame.origin.y
+                    ]);
+                } else if(rowCorner.y < this.selector.selectionFrame.origin.y){
+                    // The new row is "above" the current selection.
+                    // The anchor should be set to the bottom right of
+                    // what will be the union frame.
+                    this.selector.anchor = new Point([
+                        this.dataFrame.right,
+                        this.selector.selectionFrame.corner.y
+                    ]);
+                }
+            }
+            this.selector.selectFromAnchorTo(rowOrigin);
+            this.selector.cursor = new Point([
+                this.selector.cursor.x,
+                event.target.row
+            ]);
+            this.selector.triggerCallback();
+        } else if(event.target.isColumnTab && event.button === 0){
+            let colOrigin = new Point([event.target.relativeColumn, 0]);
+            let colCorner = new Point([event.target.relativeColumn, this.dataFrame.bottom]);
+            this.selector.anchor = colCorner;
+            if(event.shiftKey){
+                if(colCorner.x > this.selector.selectionFrame.origin.x){
+                    // The new column is to the right of the current selection.
+                    // Set the anchor to the bottom left corner of what wil
+                    // be the union frame.
+                    this.selector.anchor = new Point([
+                        this.selector.selectionFrame.origin.x,
+                        this.dataFrame.bottom
+                    ]);
+                } else if(colCorner.x < this.selector.selectionFrame.origin.x){
+                    // The new column is to the left of the current selection.
+                    // The anchor should be set to the bottom right
+                    // of what will be the union frame.
+                    this.selector.anchor = new Point([
+                        this.selector.selectionFrame.corner.x,
+                        this.dataFrame.bottom
+                    ]);
+                }
+            }
+            this.selector.selectFromAnchorTo(colOrigin);
+            this.selector.cursor = new Point([
+                event.target.column,
+                this.selector.cursor.y
+            ]);
+            this.selector.triggerCallback();
         }
     }
 

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -170,6 +170,7 @@ class GridSheet extends HTMLElement {
         this.onObservedResize = this.onObservedResize.bind(this);
         this.onCellEdit = this.onCellEdit.bind(this);
         this.onDataChanged = this.onDataChanged.bind(this);
+        this.onTabClick = this.onTabClick.bind(this);
         this.render = this.render.bind(this);
         this.renderGridTemplate = this.renderGridTemplate.bind(this);
         this.renderRowTabs = this.renderRowTabs.bind(this);
@@ -441,25 +442,44 @@ class GridSheet extends HTMLElement {
 
             // Add event listener for clicking to
             // select whole row
-            tab.addEventListener('click', (event) => {
-                if(event.button == 0){
-                    let targetPoint = new Point([0, event.target.relativeRow]);
-                    this.selector.anchor = targetPoint;
-                    let endPoint = new Point([
-                        this.dataFrame.right,
-                        targetPoint.y
-                    ]);
-                    this.selector.selectFromAnchorTo(endPoint);
-                    this.selector.cursor = new Point([
-                        this.selector.cursor.x,
-                        tab.row
-                    ]);
-                    this.selector.triggerCallback();
-                }
-            });
+            // tab.addEventListener('click', (event) => {
+            //     if(event.button == 0){
+            //         let targetPoint = new Point([0, event.target.relativeRow]);
+            //         this.selector.anchor = targetPoint;
+            //         let endPoint = new Point([
+            //             this.dataFrame.right,
+            //             targetPoint.y
+            //         ]);
+            //         this.selector.selectFromAnchorTo(endPoint);
+            //         this.selector.cursor = new Point([
+            //             this.selector.cursor.x,
+            //             tab.row
+            //         ]);
+            //         this.selector.triggerCallback();
+            //     }
+            // });
+            tab.addEventListener('click', this.onTabClick.bind(this));
 
             // Add event listener for row adjustment
             tab.addEventListener('row-adjustment', this.handleRowAdjustment);
+        }
+    }
+
+    onTabClick(event){
+        if(event.target.isRowTab && event.button === 0){
+            let rowOrigin = new Point([0, event.target.relativeRow]);
+            let rowCorner = new Point([this.dataFrame.right, event.target.relativeRow]);
+            let rowRelativeFrame = new Frame(rowOrigin, rowCorner);
+            if(event.shiftKey){
+                
+            } else {
+                this.selector.anchor = rowOrigin;
+            }
+            this.selector.selectFromAnchorTo(rowCorner);
+            // Update the cursor?
+            this.selector.triggerCallback();
+        } else if(event.target.isColumnTab && event.button === 0){
+            
         }
     }
 

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -71,6 +71,8 @@ class RowTab extends HTMLElement {
         this.row = 0;
         this.relativeRow = 0;
 
+        this.isRowTab = true;
+
         // a Cached version of the measurment
         this._cachedHeight = null;
         this._cachedMouseY = 0;
@@ -201,6 +203,8 @@ class ColumnTab extends HTMLElement {
 
         this.column = 0;
         this.relativeColumn = 0;
+
+        this.isColumnTab = true;
 
         // a Cached version of the measurment
         this._cachedWidth = null;


### PR DESCRIPTION
## What ##
This PR implements shift-clicking on column/row tabs such that doing so will select the union of the new column/row and the existing selection (ie, you can select a range between multiple rows/columns by shift clicking a corresponding tab).
 
