### PR TITLE
Direct Cell Editing

### DIFF
--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -611,7 +611,6 @@ class GridSheet extends HTMLElement {
     }
 
     handleCellEdited(event){
-        console.log(event.target);
         this.focus();
     }
 

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -168,7 +168,6 @@ class GridSheet extends HTMLElement {
 
         // Bind instace methods
         this.onObservedResize = this.onObservedResize.bind(this);
-        this.onCellEdit = this.onCellEdit.bind(this);
         this.onDataChanged = this.onDataChanged.bind(this);
         this.onTabClick = this.onTabClick.bind(this);
         this.render = this.render.bind(this);
@@ -187,7 +186,7 @@ class GridSheet extends HTMLElement {
         this.handleViewShift = this.handleViewShift.bind(this);
         this.handleColumnAdjustment = this.handleColumnAdjustment.bind(this);
         this.handleRowAdjustment = this.handleRowAdjustment.bind(this);
-        this.afterEditChange = this.afterEditChange.bind(this);
+        this.handleCellEdited = this.handleCellEdited.bind(this);
     }
 
     connectedCallback(){
@@ -221,6 +220,7 @@ class GridSheet extends HTMLElement {
         // Event listeners
         this.addEventListener('selection-changed', this.handleSelectionChanged);
         this.addEventListener('sheet-view-shifted', this.handleViewShift);
+        this.addEventListener('cell-edited', this.handleCellEdited);
     }
 
     disconnectedCallback(){
@@ -230,6 +230,7 @@ class GridSheet extends HTMLElement {
         this.clipboardHandler.disconnect();
         this.removeEventListener('selection-changed', this.handleSelectionChanged);
         this.removeEventListener('sheet-view-shifted', this.handleViewShift);
+        this.removeEventListener('cell-edited', this.handleCellEdited);
     }
 
     attributeChangedCallback(name, oldVal, newVal){
@@ -280,41 +281,6 @@ class GridSheet extends HTMLElement {
         let newColumns = Math.floor((rect.width) / currentCellWidth);
         this.setAttribute('columns', newColumns);
         this.render();
-    }
-
-    onCellEdit(){
-        let editArea = this.shadowRoot.getElementById('edit-area');
-        let isDisabled = editArea.hasAttribute('disabled');
-        if(isDisabled){
-            // Highlight the cell that is being edited.
-            let cell = this.primaryFrame.elementAt(this.selector.cursor);
-            this.classList.add('editing-cell');
-            cell.classList.add('editing');
-            
-            // Prep the editor input for editing
-            // and focus on it automatically
-            editArea.removeAttribute("disabled");
-            editArea.select();
-            editArea.focus();
-            editArea.addEventListener('change', this.afterEditChange);
-        }
-        
-    }
-
-    afterEditChange(event){
-        event.currentTarget.removeEventListener('change', this.afterEditChange);
-        event.currentTarget.setAttribute('disabled', 'true');
-        this.focus();
-
-        // Remove styling from the cell that
-        // was being edited
-        let cell = this.primaryFrame.elementAt(this.selector.cursor);
-        this.classList.remove('editing-cell');
-        cell.classList.remove('editing');
-
-        // Update the DataFrame and redraw view frame
-        this.dataFrame.putAt(this.selector.relativeCursor, event.currentTarget.value);
-        this.primaryFrame.updateCellContents();
     }
 
     updateNumRows(){
@@ -642,6 +608,11 @@ class GridSheet extends HTMLElement {
     handleRowAdjustment(event){
         this.customRows[event.target.row] = event.detail.newHeight;
         this.renderGridTemplate();
+    }
+
+    handleCellEdited(event){
+        console.log(event.target);
+        this.focus();
     }
 
     trackSelectionWithRowTabs(){

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -133,6 +133,9 @@ class GridSheet extends HTMLElement {
             this.template.content.cloneNode(true)
         );
 
+        // Testers
+        this.isSheet = true;
+
         // Default cell dimensions
         this.cellWidth = 150;
         this.cellHeight = 36;

--- a/src/KeyHandler.js
+++ b/src/KeyHandler.js
@@ -51,6 +51,18 @@ class KeyHandler extends Object {
         let handler = this.handlers[event.key];
         if(handler){
             handler(event);
+        } else {
+            // If no specific handler was found,
+            // check to see if this is a key that
+            // will enter data into the cell and,
+            // if so, enable live editing of the
+            // cell.
+            let cellElement = this.sheet.primaryFrame.elementAt(
+                this.sheet.selector.cursor
+            );
+            cellElement.setAttribute('editing', 'true');
+            cellElement.textContent += event.key;
+            console.log(event);
         }
     }
 

--- a/src/KeyHandler.js
+++ b/src/KeyHandler.js
@@ -51,12 +51,13 @@ class KeyHandler extends Object {
         let handler = this.handlers[event.key];
         if(handler){
             handler(event);
-        } else if(event.key.length === 1){
+        } else if(event.key.length === 1 && !this.usesModifierKeys(event)){
             // If no specific handler was found,
             // check to see if this is a key that
             // will enter data into the cell and,
             // if so, enable live editing of the
             // cell.
+            console.log(event);
             let cellElement = this.sheet.primaryFrame.elementAt(
                 this.sheet.selector.cursor
             );
@@ -150,6 +151,10 @@ class KeyHandler extends Object {
                 }
             }
         });
+    }
+
+    usesModifierKeys(event){
+        return (event.altKey || event.ctrlKey || event.metaKey);
     }
 };
 

--- a/src/KeyHandler.js
+++ b/src/KeyHandler.js
@@ -57,7 +57,6 @@ class KeyHandler extends Object {
             // will enter data into the cell and,
             // if so, enable live editing of the
             // cell.
-            console.log(event);
             let cellElement = this.sheet.primaryFrame.elementAt(
                 this.sheet.selector.cursor
             );

--- a/src/KeyHandler.js
+++ b/src/KeyHandler.js
@@ -1,4 +1,4 @@
-/**
+ /**
  * KeyHandler class
  * ----------------
  * I am a controller object that
@@ -51,7 +51,7 @@ class KeyHandler extends Object {
         let handler = this.handlers[event.key];
         if(handler){
             handler(event);
-        } else {
+        } else if(event.key.length === 1){
             // If no specific handler was found,
             // check to see if this is a key that
             // will enter data into the cell and,
@@ -60,9 +60,9 @@ class KeyHandler extends Object {
             let cellElement = this.sheet.primaryFrame.elementAt(
                 this.sheet.selector.cursor
             );
-            cellElement.setAttribute('editing', 'true');
-            cellElement.textContent += event.key;
-            console.log(event);
+            if(!cellElement.hasAttribute('editing')){
+                cellElement.setAttribute('editing', 'true');
+            }
         }
     }
 
@@ -141,7 +141,13 @@ class KeyHandler extends Object {
         });
         this.registerHandler('Enter', (event) => {
             if(this.sheet.selector.selectionFrame.isEmpty){
-                this.sheet.onCellEdit();
+                let cellElement = this.sheet.primaryFrame.elementAt(
+                    this.sheet.selector.cursor
+                );
+                if(!cellElement.isEditing){
+                    cellElement.setAttribute('editing', true);
+                    event.stopPropagation();
+                }
             }
         });
     }

--- a/src/SheetCell.js
+++ b/src/SheetCell.js
@@ -169,6 +169,8 @@ class SheetCell extends HTMLElement {
                 bubbles: true
             });
             this.dispatchEvent(newEvent);
+        } else if(event.key.startsWith("Arrow")){
+            event.stopPropagation();
         }
     }
 


### PR DESCRIPTION
## What ##
The PR implements the direct editing of cell contents after the user triggers certain events.
  
## Implementation ##
### SheetCell Updates ###
We have updated `<sheet-cell>` to have a new reactive attribute called `editing=`. When it is set to true, the element configures itself to be directly edited.
  
This is accomplished by means of a previously hidden `<input>` in the shadow dom that will become active and focused. 
  
### KeyHandler and triggering edit mode ###
From the GridSheet's perspective, there are three ways to "enter edit mode" on the cell that the cursor is currently on top of:
1. Double click any cell;
2. Press the Enter/Return key (will trigger edit mode if you are not already editing)
3. Press any key that represents a single character
  
### Saving Edits ###
Any navigation away from a cell that is being edited (via clicking or something else) will discard any changes and restore the cell's previous value.
  
To finalize edits in a cell, currently the only option is to press the Enter/Return key while in edit mode. Doing so saves the result, triggers the `cell-edited` custom event (see below), and deactivates edit mode on the cell.
  
### `cell-edited` custom event ###
Making changes to a cell's contents will now dispatch the `cell-edited` custom event from the given `sheet-cell`. The event bubbles.
  
## Closes ##
Issue #4 