### PR TITLE
Sheet Resizing v2

### DIFF
--- a/examples/wrapped-table.html
+++ b/examples/wrapped-table.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Basic Grid Tests</title>
+        <link rel="stylesheet" href="style.css">
+        <script type="module" src="../src/GridSheet.js"></script>
+        <script type="module" src="../src/SheetCell.js"></script>
+    </head>
+    <body>
+        <div style="resize: both;padding:3px;background-color:grey;width:50%;overflow:auto">
+            <my-grid class="spreadsheet" id="table" rows="10" columns="5" expands="both">
+            </my-grid>
+        </div>
+    </body>
+    <script>
+     document.addEventListener('DOMContentLoaded', () => {
+         let table = document.getElementById('table');
+         table.focus();
+     });
+    </script>
+</html>

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -288,12 +288,10 @@ class GridSheet extends HTMLElement {
     }
 
     updateNumRows(){
+        if(this.numRows <= 0){
+            this.numRows = 1;
+        }
         this.render();
-
-        // If there are column tabs showing,
-        // mark the ones that should be locked
-        // as locked
-        
     }
 
     updateLockedRows(){
@@ -305,6 +303,9 @@ class GridSheet extends HTMLElement {
     }
 
     updateNumColumns(){
+        if(this.numColumns <= 0){
+            this.numColumns = 1;
+        }
         this.render();
     }
 

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -29,6 +29,7 @@ const templateString = `
 :host {
    display: grid;
    user-select: none;
+   overflow: hidden; /* For auto-resize without scrolling on */
 }
 
 :host(:focus){

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -293,8 +293,11 @@ class GridSheet extends HTMLElement {
         const roData = info[0];
         const rect = roData.target.getBoundingClientRect();
         const currentCellWidth = this.cellWidth;
+        const currentCellHeight = this.cellHeight;
         const newColumns = Math.floor((rect.width) / currentCellWidth);
+        const newRows = Math.floor((rect.height) / currentCellHeight);
         this.setAttribute('columns', newColumns);
+        this.setAttribute('rows', newRows);
         this.render();
     }
 

--- a/src/ResizeHandler.js
+++ b/src/ResizeHandler.js
@@ -28,7 +28,6 @@ class ResizeHandler extends Object {
     }
 
     disconnect(){
-        console.log('resizeHandler disconnecting');
         let parentElement = this.sheet.parentElement;
         if(!parentElement){
             parentElement = this.sheet.getRootNode().host;
@@ -84,7 +83,6 @@ class ResizeHandler extends Object {
     }
 
     _updateHeight(parentHeight){
-        console.log('updateHeight');
         let currentHeight = this.calcCurrentHeight();
         let availableHeight = parentHeight - currentHeight;
         if(availableHeight > 0){
@@ -132,12 +130,17 @@ class ResizeHandler extends Object {
                 );
                 lastRowHeight = lastRow.getBoundingClientRect().height;
             }
-            this.sheet.setAttribute('rows', this.sheet.numRows - numRowsToRemove);
+
+            // We always ensure that there is at least one row
+            let newTotalRows = this.sheet.numRows - numRowsToRemove;
+            if(newTotalRows <= 0){
+                newTotalRows = 1;
+            }
+            this.sheet.setAttribute('rows', newTotalRows);
         }
     }
 
     _updateWidth(parentWidth){
-        console.log('updateWidth');
         let currentWidth = this.calcCurrentWidth();
         let availableWidth = parentWidth - currentWidth;
         if(availableWidth > 0){
@@ -179,7 +182,11 @@ class ResizeHandler extends Object {
                 lastColumn = this.sheet.shadowRoot.querySelector(`column-tab:nth-last-of-type(${currentColumnIndex})`);
                 lastColumnWidth = lastColumn.getBoundingClientRect().width;
             }
-            this.sheet.setAttribute('columns', this.sheet.numColumns - numColumnsToRemove);
+            let newTotalColumns = this.sheet.numColumns - numColumnsToRemove;
+            if(newTotalColumns <= 0){
+                newTotalColumns = 1;
+            }
+            this.sheet.setAttribute('columns', newTotalColumns);
         }
     }
 

--- a/src/ResizeHandler.js
+++ b/src/ResizeHandler.js
@@ -1,0 +1,208 @@
+class ResizeHandler extends Object {
+    constructor(element, horizontal=false, vertical=false){
+        super();
+        this.sheet = element;
+        this.horizontal = horizontal;
+        this.vertical = vertical;
+        this.isConnected = false;
+
+        // Bound instance methods
+        this.connect = this.connect.bind(this);
+        this.disconnect = this.disconnect.bind(this);
+        this.updateFromExpandsAttr = this.updateFromExpandsAttr.bind(this);
+        this.onObservedResize = this.onObservedResize.bind(this);
+        this.calcCurrentWidth = this.calcCurrentWidth.bind(this);
+        this.calcCurrentHeight = this.calcCurrentHeight.bind(this);
+        this._updateWidth = this._updateWidth.bind(this);
+        this._updateHeight = this._updateHeight.bind(this);
+    }
+    
+    connect(){
+        this.observer = new ResizeObserver(this.onObservedResize.bind(this));
+        let parentElement = this.sheet.parentElement;
+        if(!parentElement){
+            parentElement = this.sheet.getRootNode().host;
+        }
+        this.observer.observe(parentElement);
+        this.isConnected = true;
+    }
+
+    disconnect(){
+        console.log('resizeHandler disconnecting');
+        let parentElement = this.sheet.parentElement;
+        if(!parentElement){
+            parentElement = this.sheet.getRootNode().host;
+        }
+        this.observer.unobserve(parentElement);
+        this.observer.disconnect();
+        this.isConnected = false;
+    }
+
+    updateFromExpandsAttr(aString){
+        // Update the horizontal and/or
+        // vertical properties based on the
+        // incoming string, which comes from
+        // the `expands=` attribute of the target
+        // sheet.
+        if(!["both", "rows", "columns"].includes(aString)){
+            this.disconnect();
+            return;
+        }
+        if(aString === "both"){
+            this.vertical = true;
+            this.horizontal = true;
+        } else if(aString === "rows"){
+            this.vertical = true;
+            this.horizontal = false;
+        } else if(aString === "columns"){
+            this.vertical = false;
+            this.horizontal = true;
+        }
+
+        // Finally, connect if we are
+        // not already connected.
+        if(!this.isConnected){
+            this.connect();
+        }
+    }
+
+    onObservedResize(info){
+        // Attempt to re-set the number of columns and rows
+        // based upon the available free space in the element.
+        if(!this.horizontal && !this.vertical){
+            return;
+        }
+        const roData = info[0];
+        const rect = roData.target.getBoundingClientRect();
+        if(this.horizontal){
+            this._updateWidth(rect.width);
+        }
+        if(this.vertical){
+            this._updateHeight(rect.height);
+        }
+        this.sheet.render();
+    }
+
+    _updateHeight(parentHeight){
+        console.log('updateHeight');
+        let currentHeight = this.calcCurrentHeight();
+        let availableHeight = parentHeight - currentHeight;
+        if(availableHeight > 0){
+            // In this case we are expanding.
+            // We will need to check the cache
+            // of row settings to make sure that
+            // the next available rows are explicitly
+            // set to a width value, otherwise use
+            // the default values for row height
+            let currentLastRow = this.sheet.shadowRoot.querySelector(
+                `row-tab:last-of-type`
+            ).relativeRow;
+            let numRowsToAdd = 0;
+            let nextRowHeight = this.sheet.customRows[currentLastRow];
+            if(nextRowHeight === undefined){
+                nextRowHeight = this.sheet.cellHeight;
+            }
+            while(availableHeight >= nextRowHeight){
+                availableHeight -= nextRowHeight;
+                numRowsToAdd += 1;
+                currentLastRow += 1;
+                nextRowHeight = this.sheet.customRows[currentLastRow];
+                if(nextRowHeight === undefined){
+                    nextRowHeight = this.sheet.cellHeight;
+                }
+            }
+            this.sheet.setAttribute('rows', this.sheet.numRows + numRowsToAdd);
+        } else if(availableHeight < 0){
+            // In this case, we are shrinking.
+            // We need to remove rows one at a time
+            // and make sure we get the available space
+            // to be greater than or equal to zero.
+            let numRowsToRemove = 0;
+            let currentRowIndex = 1;
+            let lastRow = this.sheet.shadowRoot.querySelector(
+                `row-tab:nth-last-of-type(${currentRowIndex})`
+            );
+            let lastRowHeight = lastRow.getBoundingClientRect().height;
+            while(availableHeight < 0){
+                availableHeight += lastRowHeight;
+                numRowsToRemove += 1;
+                currentRowIndex += 1;
+                lastRow = this.sheet.shadowRoot.querySelector(
+                    `row-tab:nth-last-of-type(${currentRowIndex})`
+                );
+                lastRowHeight = lastRow.getBoundingClientRect().height;
+            }
+            this.sheet.setAttribute('rows', this.sheet.numRows - numRowsToRemove);
+        }
+    }
+
+    _updateWidth(parentWidth){
+        console.log('updateWidth');
+        let currentWidth = this.calcCurrentWidth();
+        let availableWidth = parentWidth - currentWidth;
+        if(availableWidth > 0){
+            // In this case, we are expanding.
+            // We will need to check the cache
+            // of column settings to make sure that
+            // next available columns are explicitly
+            // set to a width value, otherwise use
+            // the default values for column width.
+            let currentLastCol = this.sheet.shadowRoot.querySelector('column-tab:last-of-type').relativeColumn;
+            let numColumnsToAdd = 0;
+            let nextColumnWidth = this.sheet.customColumns[currentLastCol];
+            if(nextColumnWidth === undefined){
+                nextColumnWidth = this.sheet.cellWidth;
+            }
+            while(availableWidth >= nextColumnWidth){
+                availableWidth -= nextColumnWidth;
+                numColumnsToAdd += 1;
+                currentLastCol += 1;
+                nextColumnWidth = this.sheet.customColumns[currentLastCol];
+                if(nextColumnWidth === undefined){
+                    nextColumnWidth = this.sheet.cellWidth;
+                }
+            }
+            this.sheet.setAttribute('columns', this.sheet.numColumns + numColumnsToAdd);
+        } else if(availableWidth < 0){
+            // In this case, we are shrinking.
+            // We need to remove columns one at a time
+            // and make sure we get the available space
+            // to be greater than or equal to zero
+            let numColumnsToRemove = 0;
+            let currentColumnIndex = 1;
+            let lastColumn = this.sheet.shadowRoot.querySelector(`column-tab:nth-last-of-type(${currentColumnIndex})`);
+            let lastColumnWidth = lastColumn.getBoundingClientRect().width;
+            while(availableWidth < 0){
+                availableWidth += lastColumnWidth;
+                numColumnsToRemove += 1;
+                currentColumnIndex += 1;
+                lastColumn = this.sheet.shadowRoot.querySelector(`column-tab:nth-last-of-type(${currentColumnIndex})`);
+                lastColumnWidth = lastColumn.getBoundingClientRect().width;
+            }
+            this.sheet.setAttribute('columns', this.sheet.numColumns - numColumnsToRemove);
+        }
+    }
+
+    calcCurrentWidth(){
+        // We use the top row's
+        // rightmost cell
+        let rightmostCellSelector = `sheet-cell[data-x="${this.sheet.numColumns - 1}"]`;
+        let rightmostCell = this.sheet.querySelector(rightmostCellSelector);
+        let right = rightmostCell.getBoundingClientRect().right;
+        return Math.ceil(right);
+    }
+
+    calcCurrentHeight(){
+        // We use the left column's
+        // bottom sheet cell.
+        let bottomCellSelector = `sheet-cell[data-y="${this.sheet.numRows - 1}"]`;
+        let bottomCell = this.sheet.querySelector(bottomCellSelector);
+        let bottom = bottomCell.getBoundingClientRect().bottom;
+        return Math.ceil(bottom);
+    }
+}
+
+export {
+    ResizeHandler,
+    ResizeHandler as default
+};

--- a/src/ResizeHandler.js
+++ b/src/ResizeHandler.js
@@ -100,7 +100,7 @@ class ResizeHandler extends Object {
             if(nextRowHeight === undefined){
                 nextRowHeight = this.sheet.cellHeight;
             }
-            while(availableHeight >= nextRowHeight){
+            while(availableHeight > 0){
                 availableHeight -= nextRowHeight;
                 numRowsToAdd += 1;
                 currentLastRow += 1;
@@ -110,7 +110,7 @@ class ResizeHandler extends Object {
                 }
             }
             this.sheet.setAttribute('rows', this.sheet.numRows + numRowsToAdd);
-        } else if(availableHeight < 0){
+        } else if((availableHeight + this.sheet.cellHeight) < 0){
             // In this case, we are shrinking.
             // We need to remove rows one at a time
             // and make sure we get the available space
@@ -152,7 +152,7 @@ class ResizeHandler extends Object {
             if(nextColumnWidth === undefined){
                 nextColumnWidth = this.sheet.cellWidth;
             }
-            while(availableWidth >= nextColumnWidth){
+            while(availableWidth > 0){
                 availableWidth -= nextColumnWidth;
                 numColumnsToAdd += 1;
                 currentLastCol += 1;
@@ -171,7 +171,7 @@ class ResizeHandler extends Object {
             let currentColumnIndex = 1;
             let lastColumn = this.sheet.shadowRoot.querySelector(`column-tab:nth-last-of-type(${currentColumnIndex})`);
             let lastColumnWidth = lastColumn.getBoundingClientRect().width;
-            while(availableWidth < 0 && this.sheet.numColumns > 1){
+            while((availableWidth + this.sheet.cellWidth) < 0 && this.sheet.numColumns > 1){
                 availableWidth += lastColumnWidth;
                 numColumnsToRemove += 1;
                 currentColumnIndex += 1;

--- a/src/ResizeHandler.js
+++ b/src/ResizeHandler.js
@@ -121,7 +121,7 @@ class ResizeHandler extends Object {
                 `row-tab:nth-last-of-type(${currentRowIndex})`
             );
             let lastRowHeight = lastRow.getBoundingClientRect().height;
-            while(availableHeight < 0){
+            while(availableHeight < 0 && this.sheet.numRows > 1){
                 availableHeight += lastRowHeight;
                 numRowsToRemove += 1;
                 currentRowIndex += 1;
@@ -131,11 +131,7 @@ class ResizeHandler extends Object {
                 lastRowHeight = lastRow.getBoundingClientRect().height;
             }
 
-            // We always ensure that there is at least one row
             let newTotalRows = this.sheet.numRows - numRowsToRemove;
-            if(newTotalRows <= 0){
-                newTotalRows = 1;
-            }
             this.sheet.setAttribute('rows', newTotalRows);
         }
     }
@@ -175,7 +171,7 @@ class ResizeHandler extends Object {
             let currentColumnIndex = 1;
             let lastColumn = this.sheet.shadowRoot.querySelector(`column-tab:nth-last-of-type(${currentColumnIndex})`);
             let lastColumnWidth = lastColumn.getBoundingClientRect().width;
-            while(availableWidth < 0){
+            while(availableWidth < 0 && this.sheet.numColumns > 1){
                 availableWidth += lastColumnWidth;
                 numColumnsToRemove += 1;
                 currentColumnIndex += 1;
@@ -183,9 +179,6 @@ class ResizeHandler extends Object {
                 lastColumnWidth = lastColumn.getBoundingClientRect().width;
             }
             let newTotalColumns = this.sheet.numColumns - numColumnsToRemove;
-            if(newTotalColumns <= 0){
-                newTotalColumns = 1;
-            }
             this.sheet.setAttribute('columns', newTotalColumns);
         }
     }


### PR DESCRIPTION
## What ##
This PR deals with configuring and handling the automatic resizing of GridSheet within its parent element or shadow dom root node host.
  
We now allow for specifying `rows`, `columns`, or `both` as attribute values of the element's `expands=` attribute. Setting any other value disables automatic resizing completely.
  
## Implementation ##
With this PR we introduce a new handler class called `ResizeHandler`, which is a wrapper that incorporates a native API [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) under the hood.
  
The `ResizeHandler` also performs the needed calculations on its corresponding sheet in order to determine how much space to resize vertically or horizontally (if at all). 
  
Resizing is complicated by the fact that we allow users to specify custom widths and heights for certain columns and rows via the mouse pointer. These columns and rows might not be in the current "view", but they are stored according to their data-relative locations. Resizing also needs to do a lookup to see if the next cell falls within such a row and/or column first, etc.
  
The `ResizeHandler` also has a convenience method called `updateFromExpandsAttr()`, which is called from the GridSheet's observed attributes callback with the new attribute value. This way the handler has full control over how to configure itself based on a simple attribute string value.
  
## Testing ##
Simply load the default example sheet in your browser. In the default markup, **it is set to an invalid value** and therefore will not resize in either direction. You can set the `expands=` attribute to "both", "rows" (for vertical resizing), or "columns" (for horizontal resizing).