### PR TITLE
Cell Resizing v2

### DIFF
--- a/examples/wrapped-table.html
+++ b/examples/wrapped-table.html
@@ -7,9 +7,13 @@
         <script type="module" src="../src/SheetCell.js"></script>
     </head>
     <body>
-        <div style="resize: both;padding:3px;background-color:grey;width:50%;overflow:auto">
-            <my-grid class="spreadsheet" id="table" rows="10" columns="5" expands="both">
-            </my-grid>
+        <div id="wrapper">
+            <div id="wrap-header">HEADER</div>
+            <div id="wrapped-content" style="background-color:grey;">
+                <my-grid class="spreadsheet" id="table" rows="10" columns="5" expands="both">
+                </my-grid>
+            </div>
+            <div id="wrap-footer">FOOTER</div>
         </div>
     </body>
     <script>
@@ -18,4 +22,35 @@
          table.focus();
      });
     </script>
+    <style>
+     * {
+         box-sizing: border-box;
+     }
+     #wrapper {
+         padding: 20px;
+         display: flex;
+         flex-direction: column;
+         resize: both;
+         overflow: hidden;
+     }
+
+     #wrapped-content {
+         display: block;
+         background-color: yellow;
+         flex: 1;
+         box-sizing: content-box;
+         overflow: auto;
+     }
+
+     my-grid {
+     }
+
+     #wrap-header,
+     #wrap-footer {
+         position: relative;
+         display: block;
+         height: 50px;
+         background-color: red;
+     }
+    </style>
 </html>

--- a/examples/wrapped-table.html
+++ b/examples/wrapped-table.html
@@ -32,6 +32,7 @@
          flex-direction: column;
          resize: both;
          overflow: hidden;
+         width: 50%;
      }
 
      #wrapped-content {
@@ -42,7 +43,8 @@
          overflow: auto;
      }
 
-     my-grid {
+     #wrapped-content > my-grid {
+         width: max-content;
      }
 
      #wrap-header,

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -385,7 +385,7 @@ class GridSheet extends HTMLElement {
             if(this.customRows[relativeY]){
                 row += `[cell-row-start] ${this.customRows[relativeY]}px `;
             } else {
-                row += `[cell-row-start] 1fr `;
+                row += `[cell-row-start] ${this.cellHeight}px`;
             }
         }
         if(this.showColumnTabs){

--- a/src/ResizeHandler.js
+++ b/src/ResizeHandler.js
@@ -91,7 +91,29 @@ class ResizeHandler extends Object {
         }, 250);
     }
 
-    _shrinkHeight(availableHeight){}
+    _shrinkHeight(availableHeight){
+        let freespace = Math.floor(availableHeight);
+        let currentLastRow, lastRowHeight;
+        let numRowsToRemove = 0;
+        let currentRowIndex = 1;
+        while((freespace + this.sheet.cellHeight) < 0){
+            currentLastRow = this.sheet.shadowRoot.querySelector(
+                `row-tab:nth-last-of-type(${currentRowIndex})`
+            );
+            if(!currentLastRow){
+                break;
+            }
+            lastRowHeight = currentLastRow.getBoundingClientRect().height;
+            numRowsToRemove += 1;
+            currentRowIndex += 1;
+            freespace += lastRowHeight;
+        }
+        let newTotalRows = this.sheet.numRows - numRowsToRemove;
+        if(newTotalRows < 1){
+            newTotalRows = 1;
+        }
+        this.sheet.setAttribute('rows', newTotalRows);
+    }
 
     _fillHeight(availableHeight){
         let freespace = Math.floor(availableHeight);

--- a/src/ResizeHandler.js
+++ b/src/ResizeHandler.js
@@ -9,6 +9,8 @@ class ResizeHandler extends Object {
         // Bound instance methods
         this.connect = this.connect.bind(this);
         this.disconnect = this.disconnect.bind(this);
+        this.pause = this.pause.bind(this);
+        this.restart = this.restart.bind(this);
         this.updateFromExpandsAttr = this.updateFromExpandsAttr.bind(this);
         this.onObservedResize = this.onObservedResize.bind(this);
         this.calcCurrentWidth = this.calcCurrentWidth.bind(this);
@@ -19,20 +21,20 @@ class ResizeHandler extends Object {
     
     connect(){
         this.observer = new ResizeObserver(this.onObservedResize.bind(this));
-        let parentElement = this.sheet.parentElement;
-        if(!parentElement){
-            parentElement = this.sheet.getRootNode().host;
-        }
-        this.observer.observe(parentElement);
+        this.observer.observe(this.observedParentElement);
         this.isConnected = true;
     }
 
+    pause(){
+        this.observer.unobserve(this.observedParentElement);
+    }
+
+    restart(){
+        this.observer.observe(this.observedParentElement);
+    }
+
     disconnect(){
-        let parentElement = this.sheet.parentElement;
-        if(!parentElement){
-            parentElement = this.sheet.getRootNode().host;
-        }
-        this.observer.unobserve(parentElement);
+        this.observer.unobserve(this.observedParentElement);
         this.observer.disconnect();
         this.isConnected = false;
     }
@@ -68,137 +70,186 @@ class ResizeHandler extends Object {
     onObservedResize(info){
         // Attempt to re-set the number of columns and rows
         // based upon the available free space in the element.
-        if(!this.horizontal && !this.vertical){
-            return;
+        if(this._cachedTimeoutId){
+            window.clearTimeout(this._cachedTimeoutId);
         }
-        const roData = info[0];
-        const rect = roData.target.getBoundingClientRect();
-        if(this.horizontal){
-            this._updateWidth(rect.width);
-        }
-        if(this.vertical){
-            this._updateHeight(rect.height);
-        }
-        this.sheet.render();
+        this._cachedTimeoutId = window.setTimeout(() => {
+            if(!this.horizontal && !this.vertical){
+                return;
+            }
+            const roData = info[0];
+            const containerRect = roData.target.getBoundingClientRect();
+            const sheetRect = this.sheet.getBoundingClientRect();
+            console.log(`clientHeight: ${roData.target.clientHeight} scrollHeight: ${roData.target.scrollHeight}`);
+            if(this.horizontal){
+                this._updateWidth(containerRect.width, sheetRect.width);
+            }
+            if(this.vertical){
+                this._updateHeight(containerRect.height, sheetRect.height);
+            }
+            this.sheet.render();
+        }, 250);
     }
 
-    _updateHeight(parentHeight){
-        let currentHeight = this.calcCurrentHeight();
-        let availableHeight = parentHeight - currentHeight;
-        if(availableHeight > 0){
-            // In this case we are expanding.
-            // We will need to check the cache
-            // of row settings to make sure that
-            // the next available rows are explicitly
-            // set to a width value, otherwise use
-            // the default values for row height
-            let currentLastRow = this.sheet.shadowRoot.querySelector(
+    _shrinkHeight(availableHeight){}
+
+    _fillHeight(availableHeight){
+        let freespace = Math.floor(availableHeight);
+        let currentLastRow, nextRowHeight;
+        let numRowsToAdd = 0;
+        let rowHeightAdded = 0;
+        while(freespace > 0){
+            currentLastRow = this.sheet.shadowRoot.querySelector(
                 `row-tab:last-of-type`
             ).relativeRow;
-            let numRowsToAdd = 0;
-            let nextRowHeight = this.sheet.customRows[currentLastRow];
+            nextRowHeight = this.sheet.customRows[currentLastRow];
             if(nextRowHeight === undefined){
                 nextRowHeight = this.sheet.cellHeight;
             }
-            while(availableHeight > 0){
-                availableHeight -= nextRowHeight;
-                numRowsToAdd += 1;
-                currentLastRow += 1;
-                nextRowHeight = this.sheet.customRows[currentLastRow];
-                if(nextRowHeight === undefined){
-                    nextRowHeight = this.sheet.cellHeight;
-                }
-            }
-            this.sheet.setAttribute('rows', this.sheet.numRows + numRowsToAdd);
-        } else if((availableHeight + this.sheet.cellHeight) < 0){
-            // In this case, we are shrinking.
-            // We need to remove rows one at a time
-            // and make sure we get the available space
-            // to be greater than or equal to zero.
-            let numRowsToRemove = 0;
-            let currentRowIndex = 1;
-            let lastRow = this.sheet.shadowRoot.querySelector(
-                `row-tab:nth-last-of-type(${currentRowIndex})`
-            );
-            let lastRowHeight = lastRow.getBoundingClientRect().height;
-            while(availableHeight < 0 && this.sheet.numRows > 1){
-                availableHeight += lastRowHeight;
-                numRowsToRemove += 1;
-                currentRowIndex += 1;
-                lastRow = this.sheet.shadowRoot.querySelector(
-                    `row-tab:nth-last-of-type(${currentRowIndex})`
-                );
-                lastRowHeight = lastRow.getBoundingClientRect().height;
-            }
-
-            let newTotalRows = this.sheet.numRows - numRowsToRemove;
-            this.sheet.setAttribute('rows', newTotalRows);
+            freespace = freespace - nextRowHeight;
+            rowHeightAdded += nextRowHeight;
+            numRowsToAdd += 1;
+            console.log(`freespace: ${freespace}`);
         }
+        console.log(`Adding ${numRowsToAdd} rows with collective height: ${rowHeightAdded}`);
+        this.sheet.setAttribute('rows', this.sheet.numRows + numRowsToAdd);
+        
     }
 
-    _updateWidth(parentWidth){
-        let currentWidth = this.calcCurrentWidth();
-        let availableWidth = parentWidth - currentWidth;
-        if(availableWidth > 0){
-            // In this case, we are expanding.
-            // We will need to check the cache
-            // of column settings to make sure that
-            // next available columns are explicitly
-            // set to a width value, otherwise use
-            // the default values for column width.
-            let currentLastCol = this.sheet.shadowRoot.querySelector('column-tab:last-of-type').relativeColumn;
-            let numColumnsToAdd = 0;
-            let nextColumnWidth = this.sheet.customColumns[currentLastCol];
-            if(nextColumnWidth === undefined){
-                nextColumnWidth = this.sheet.cellWidth;
-            }
-            while(availableWidth > 0){
-                availableWidth -= nextColumnWidth;
-                numColumnsToAdd += 1;
-                currentLastCol += 1;
-                nextColumnWidth = this.sheet.customColumns[currentLastCol];
-                if(nextColumnWidth === undefined){
-                    nextColumnWidth = this.sheet.cellWidth;
-                }
-            }
-            this.sheet.setAttribute('columns', this.sheet.numColumns + numColumnsToAdd);
-        } else if(availableWidth < 0){
-            // In this case, we are shrinking.
-            // We need to remove columns one at a time
-            // and make sure we get the available space
-            // to be greater than or equal to zero
-            let numColumnsToRemove = 0;
-            let currentColumnIndex = 1;
-            let lastColumn = this.sheet.shadowRoot.querySelector(`column-tab:nth-last-of-type(${currentColumnIndex})`);
-            let lastColumnWidth = lastColumn.getBoundingClientRect().width;
-            while((availableWidth + this.sheet.cellWidth) < 0 && this.sheet.numColumns > 1){
-                availableWidth += lastColumnWidth;
-                numColumnsToRemove += 1;
-                currentColumnIndex += 1;
-                lastColumn = this.sheet.shadowRoot.querySelector(`column-tab:nth-last-of-type(${currentColumnIndex})`);
-                lastColumnWidth = lastColumn.getBoundingClientRect().width;
-            }
-            let newTotalColumns = this.sheet.numColumns - numColumnsToRemove;
-            this.sheet.setAttribute('columns', newTotalColumns);
+    _updateHeight(parentHeight, sheetHeight){
+        let availableHeight = parentHeight - sheetHeight;
+        console.log(`available height: ${availableHeight}`);
+        if(availableHeight > 0){
+            this._fillHeight(availableHeight);
+        } else if(availableHeight < 0){
+            this._shrinkHeight(availableHeight);
         }
+        // let currentHeight = this.calcCurrentHeight();
+        // let availableHeight = parentHeight - currentHeight;
+        // if(availableHeight > 0){
+        //     // In this case we are expanding.
+        //     // We will need to check the cache
+        //     // of row settings to make sure that
+        //     // the next available rows are explicitly
+        //     // set to a width value, otherwise use
+        //     // the default values for row height
+        //     let currentLastRow = this.sheet.shadowRoot.querySelector(
+        //         `row-tab:last-of-type`
+        //     ).relativeRow;
+        //     let numRowsToAdd = 0;
+        //     let nextRowHeight = this.sheet.customRows[currentLastRow];
+        //     if(nextRowHeight === undefined){
+        //         nextRowHeight = this.sheet.cellHeight;
+        //     }
+        //     while(availableHeight > 0){
+        //         availableHeight -= nextRowHeight;
+        //         numRowsToAdd += 1;
+        //         currentLastRow += 1;
+        //         nextRowHeight = this.sheet.customRows[currentLastRow];
+        //         if(nextRowHeight === undefined){
+        //             nextRowHeight = this.sheet.cellHeight;
+        //         }
+        //     }
+        //     this.sheet.setAttribute('rows', this.sheet.numRows + numRowsToAdd);
+        // } else if((availableHeight + this.sheet.cellHeight) < 0){
+        //     // In this case, we are shrinking.
+        //     // We need to remove rows one at a time
+        //     // and make sure we get the available space
+        //     // to be greater than or equal to zero.
+        //     let numRowsToRemove = 0;
+        //     let currentRowIndex = 1;
+        //     let lastRow = this.sheet.shadowRoot.querySelector(
+        //         `row-tab:nth-last-of-type(${currentRowIndex})`
+        //     );
+        //     let lastRowHeight = lastRow.getBoundingClientRect().height;
+        //     while(availableHeight < 0 && this.sheet.numRows > 1){
+        //         availableHeight += lastRowHeight;
+        //         numRowsToRemove += 1;
+        //         currentRowIndex += 1;
+        //         lastRow = this.sheet.shadowRoot.querySelector(
+        //             `row-tab:nth-last-of-type(${currentRowIndex})`
+        //         );
+        //         lastRowHeight = lastRow.getBoundingClientRect().height;
+        //     }
+
+        //     let newTotalRows = this.sheet.numRows - numRowsToRemove;
+        //     this.sheet.setAttribute('rows', newTotalRows);
+        // }
+    }
+
+    _updateWidth(parentWidth, sheetWidth){
+        // let currentWidth = this.calcCurrentWidth();
+        // let availableWidth = parentWidth - currentWidth;
+        // if(availableWidth > 0){
+        //     // In this case, we are expanding.
+        //     // We will need to check the cache
+        //     // of column settings to make sure that
+        //     // next available columns are explicitly
+        //     // set to a width value, otherwise use
+        //     // the default values for column width.
+        //     let currentLastCol = this.sheet.shadowRoot.querySelector('column-tab:last-of-type').relativeColumn;
+        //     let numColumnsToAdd = 0;
+        //     let nextColumnWidth = this.sheet.customColumns[currentLastCol];
+        //     if(nextColumnWidth === undefined){
+        //         nextColumnWidth = this.sheet.cellWidth;
+        //     }
+        //     while(availableWidth > 0){
+        //         availableWidth -= nextColumnWidth;
+        //         numColumnsToAdd += 1;
+        //         currentLastCol += 1;
+        //         nextColumnWidth = this.sheet.customColumns[currentLastCol];
+        //         if(nextColumnWidth === undefined){
+        //             nextColumnWidth = this.sheet.cellWidth;
+        //         }
+        //     }
+        //     this.sheet.setAttribute('columns', this.sheet.numColumns + numColumnsToAdd);
+        // } else if(availableWidth < 0){
+        //     // In this case, we are shrinking.
+        //     // We need to remove columns one at a time
+        //     // and make sure we get the available space
+        //     // to be greater than or equal to zero
+        //     let numColumnsToRemove = 0;
+        //     let currentColumnIndex = 1;
+        //     let lastColumn = this.sheet.shadowRoot.querySelector(`column-tab:nth-last-of-type(${currentColumnIndex})`);
+        //     let lastColumnWidth = lastColumn.getBoundingClientRect().width;
+        //     while((availableWidth + this.sheet.cellWidth) < 0 && this.sheet.numColumns > 1){
+        //         availableWidth += lastColumnWidth;
+        //         numColumnsToRemove += 1;
+        //         currentColumnIndex += 1;
+        //         lastColumn = this.sheet.shadowRoot.querySelector(`column-tab:nth-last-of-type(${currentColumnIndex})`);
+        //         lastColumnWidth = lastColumn.getBoundingClientRect().width;
+        //     }
+        //     let newTotalColumns = this.sheet.numColumns - numColumnsToRemove;
+        //     this.sheet.setAttribute('columns', newTotalColumns);
+        // }
     }
 
     calcCurrentWidth(){
         // We use the top row's
         // rightmost cell
-        let rightmostCellSelector = `sheet-cell[data-x="${this.sheet.numColumns - 1}"]`;
-        let rightmostCell = this.sheet.querySelector(rightmostCellSelector);
-        let right = rightmostCell.getBoundingClientRect().right;
-        return Math.ceil(right);
+        // let rightmostCellSelector = `sheet-cell[data-x="${this.sheet.numColumns - 1}"]`;
+        // let rightmostCell = this.sheet.querySelector(rightmostCellSelector);
+        // let right = rightmostCell.getBoundingClientRect().right;
+        // return Math.ceil(right);
+        return this.sheet.getBoundingClientRect().width;
     }
 
     calcCurrentHeight(){
         // We use the left column's
         // bottom sheet cell.
-        let bottomCellSelector = `sheet-cell[data-y="${this.sheet.numRows - 1}"]`;
-        let bottomCell = this.sheet.querySelector(bottomCellSelector);
-        let bottom = bottomCell.getBoundingClientRect().bottom;
-        return Math.ceil(bottom);
+        // let bottomCellSelector = `sheet-cell[data-y="${this.sheet.numRows - 1}"]`;
+        // let bottomCell = this.sheet.querySelector(bottomCellSelector);
+        // let bottom = bottomCell.getBoundingClientRect().bottom;
+        // return Math.ceil(bottom);
+        return this.sheet.getBoundingClientRect().height;
+    }
+
+    get observedParentElement(){
+        let parentElement = this.sheet.parentElement;
+        if(!parentElement){
+            parentElement = this.sheet.getRootNode().host;
+        }
+        return parentElement;
     }
 }
 


### PR DESCRIPTION
## What ##
This PR is a reimplementation of the `ResizeHandler` for automatic resizing of a GridSheet.
  
## Implementation ##
The implementation is largely the same, though we have made some code decomposition improvements and found several bugs that were affecting proper sizing in earlier versions.
  
### `cellHeight` vs `1fr` ###
Much of our previous difficulty stemmed from an incorrect template rendering in GridSheet of row heights. Instead of using the explicit pixel measurement provided by the default value (specified at `sheet.cellHeight`), we were styling the template with cell heights of `1fr`, which is a fluid measurement in grid layouts akin to flex 1 in flex layouts, ie "divide up the remaining space  among these element heights". This led to a situation where there always seemed to be vertical free space even after resizing, because the resizer expected cells to have greater height values than they were actually rendering with.
  
This has now been resolved.
  
### Delayed Action ###
Instead of trying to re-draw and re-render the GridSheet every time there is an observed resize, we have placed this reaction behind a `setTimeout` (100ms by default). If another observed resize happens within that 100ms, the previous timeout handler is canceled and a new one is created. This is much more efficient, since we block constant recalculations when they aren't truly needed.
  
## Trying it Out ##
There is a simple example present at [http://localhost:8000/examples/wrapped-table.html](http://localhost:8000/examples/wrapped-table.html) which is simple enough for live testing purposes.