### PR TITLE
DataFrame Arrays and Minimums

### DIFF
--- a/src/DataFrame.js
+++ b/src/DataFrame.js
@@ -188,6 +188,44 @@ class DataFrame extends Frame {
     }
 
     /**
+     * Responds with a new Frame that represents the
+     * smallest required Frame to represent the store
+     * contents that have actual (defined) values.
+     */
+    get minFrame(){
+        let keyCoords = Object.keys(this.store).map(keyString => {
+            return keyString.split(",").map(numStr => {
+                return parseInt(numStr);
+            });
+        });
+        let xValues = keyCoords.map(coord => coord[0]);
+        let yValues = keyCoords.map(coord => coord[1]);
+        let origin = [
+            Math.min(...xValues),
+            Math.min(...yValues)
+        ];
+        let corner = [
+            Math.max(...xValues),
+            Math.max(...yValues)
+        ];
+        return new Frame(origin, corner);
+    }
+
+    /**
+     * Like minFrame, but preserves the true
+     * origin of the whole dataFrame, ie, responds
+     * with the minimal frame encompassing all
+     * defined values from the origin.
+     */
+    get minFrameFromOrigin(){
+        let minFrame = this.minFrame;
+        return new Frame(
+            [this.origin.x, this.origin.y],
+            [minFrame.corner.x, minFrame.corner.y]
+        );
+    }
+
+    /**
      * Responds true if the given Frame,
      * relative to this DataFrame instance,
      * has a data value set for each of the

--- a/tests/data-frame-tests.js
+++ b/tests/data-frame-tests.js
@@ -1,0 +1,70 @@
+/**
+ * APSheet DataFrame Generic Tests
+ * ------------------------------------
+ */
+import jsdomglobal from "jsdom-global";
+jsdomglobal();
+import {Frame} from "../src/Frame.js";
+import {DataFrame} from "../src/DataFrame.js";
+import {Point} from "../src/Point.js";
+import chai from "chai";
+const assert = chai.assert;
+
+describe("DataFrame Generic Tests", () => {
+    let sourceFrame = new DataFrame([0,0], [1000, 1000]);
+    beforeEach(() => {
+        sourceFrame.clear();
+    });
+    it("Should produce only the minimal data needed when getting data array (from origin)", () => {
+        /**
+         * We would like to extract only the following Data:
+         * [ [0,0] [1,0] [2,0] [3,0] [4,0] [...]
+         *   [0,1] [1,1] [2,1] [3,1] [TEST][...]
+         *   [0,2] [1,2] [2,2] [3,2] [4,2] [...]
+         *   [0,3] [1,3] [TEST][3,3] [4,3] [...]
+         *   [...] [...] [...] [...] [...] [...]
+         * ]
+         * Resulting in:
+         * [ [0,0] [1,0] [2,0] [3,0] [4,0]
+         *   [0,1] [1,1] [2,1] [3,1] [TEST]
+         *   [0,2] [1,2] [2,2] [3,2] [4,2]
+         *   [0,3] [1,3] [TEST][3,3] [4,3]
+         * ]
+         */
+        sourceFrame.putAt([4,1], "TEST");
+        sourceFrame.putAt([2,3], "TEST");
+        let expectedRowLength = 5;
+        let expectedColumnLength = 4;
+        let dataArray = sourceFrame.getDataArrayForFrame(
+            sourceFrame.minFrameFromOrigin
+        );
+        assert.equal(expectedRowLength, dataArray[0].length);
+        assert.equal(expectedColumnLength, dataArray.length);
+    });
+    it("Should produce only the minimal data needed when getting a data array (strict)", () => {
+        /**
+         * We would like to extract only the following Data:
+         * [ [0,0] [1,0] [2,0] [3,0] [4,0] [...]
+         *   [0,1] [1,1] [2,1] [3,1] [TEST][...]
+         *   [0,2] [1,2] [2,2] [3,2] [4,2] [...]
+         *   [0,3] [1,3] [TEST][3,3] [4,3] [...]
+         *   [...] [...] [...] [...] [...] [...]
+         * ]
+         * Resulting in:
+         * [
+         *   [2,1] [3,1] [TEST]
+         *   [2,2] [3,2] [4,2]
+         *   [TEST][3,3] [4,3]
+         * ]
+         */
+        sourceFrame.putAt([4,1], "TEST");
+        sourceFrame.putAt([2,3], "TEST");
+        let dataArray = sourceFrame.getDataArrayForFrame(
+            sourceFrame.minFrame
+        );
+        let expectedRowLength = 3;
+        let expectedColumnLength = 3;
+        assert.equal(expectedRowLength, dataArray[0].length);
+        assert.equal(expectedColumnLength, dataArray.length);
+    });
+});


### PR DESCRIPTION
## What ##
This PR is in response to #19.
  
The issue was that calling `getDataArrayForFrame(thisDataFrame)` would result in a huge ndarray whose values might go well beyond the actual corner of data that the DataFrame currently has values for. 
  
The best way to think of it is this: 
```
_   _   _   _   _ ...
_   _   _   X   _ ...
_   _   _   _   _ ...
_   _   X   _   _ ...
... ... ... ... ... ... ... 
```
If the DataFrame is set up initially to have 1000x1000 (which is our current default in  most places), then we don't wan `getDataArrayForFrame`, when called on the dataFrame itself, to respond with a 1000x1000 ndarray. Rather, we want the _minimum necessary enclosing_ frame that has all the defined values in the store to be returned as a nested array.
  
## Implementation ##
We introduce two new getters on DataFrame, `minFrame` and `minFrameFromOrigin`.
  
### `minFrame` ###
The `dataFrame.minFrame` will respond with a `Frame` instance whose origin and corner correspond to the absolute minimal needed based on current defined values in the store. In other words, the minX, minY for the origin and maxX, maxY for the corner (for values that are defined).
  
Given a DataFrame that looks something like this:
(_NOTE_: "TEST" corresponds to defined values. Other values indicate `undefined`, but are showing their coordinates for demonstration purposes)
```
[0,0] [1,0] [2,0] [3,0] [4,0] [...]
[0,1] [1,1] [2,1] [3,1] [TEST][...]
[0,2] [1,2] [2,2] [3,2] [4,2] [...]
[0,3] [1,3] [TEST][3,3] [4,3] [...]
[...] [...] [...] [...] [...] [...]
```
Calling `minFrame` will return a new `Frame` whose origin is `2,1` and whose corner is `4,3`. So calling `getDataArrayForFrame(dataFrame.minFrame)` would get something like:
```
[2,1] [3,1] [TEST]
[2,2] [3,2] [4,2]
[TEST][3,3] [4,3]
```
  
### `minFrameFromOrigin` ###
There are cases where we might want to preserve the origin of the DataFrame itself when composing a minFrame, ie only finding the max defined data corner. An example of such a scenario is saving a CSV: if we do not preserve the "true" origin of, say, (0,0), reloading the CSV will result in incorrect data alignment.
  
Given a DataFrame that looks something like this:
(_NOTE_: "TEST" corresponds to defined values. Other values indicate `undefined`, but are showing their coordinates for demonstration purposes)
```
[0,0] [1,0] [2,0] [3,0] [4,0] [...]
[0,1] [1,1] [2,1] [3,1] [TEST][...]
[0,2] [1,2] [2,2] [3,2] [4,2] [...]
[0,3] [1,3] [TEST][3,3] [4,3] [...]
[...] [...] [...] [...] [...] [...]
```
Calling `minFrameFromCorner` will produce a new `Frame` whose origin is `0,0` and whose corner is `4,3`.
  
So calling `getDataArrayForFrame(dataFrame.minFrameFromOrigin)` would get something like:
```
[0,0] [1,0] [2,0] [3,0] [4,0]
[0,1] [1,1] [2,1] [3,1] [TEST]
[0,2] [1,2] [2,2] [3,2] [4,2]
[0,3] [1,3] [TEST][3,3] [4,3]
```
  
## The Question of `.toArray()` ##
Because there are these two separate ways of thinking about the "minimum" necessary frame for defined data in a DataFrame, it's unclear which of these new getters any `.toArray()` implementation should use. The options are:
```
// First option
toArray(){
    return this.getDataArrayForFrame(this.minFrame);
}

// Second option
toArray() {
    return this.getDataArrayForFrame(
        this.minFrameFromOrigin
    );
}
```
  
This is something we should discuss and decide on.
  
## Tests ##
There are [new tests](https://github.com/darth-cheney/ap-sheet/compare/eric-dataframe-fixes?expand=1#diff-f72a300cb2b518d7f7c71546b3a09e56a74d248b3242a4eda7e6c66a752e3fd3) for this capability.
  
## Closes ##
#19 