### PR TITLE
adding DataFrame.copyFrom()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
     "type": "module",
     "devDependencies": {
-    "chai": "^4.3.4",
-    "esm": "^3.2.25",
-    "jsdom": "^19.0.0",
-    "jsdom-global": "^3.0.2",
-    "webpack": "^5.66.0",
-    "webpack-cli": "^4.9.1"
+        "chai": "^4.3.4",
+        "esm": "^3.2.25",
+        "jsdom": "^19.0.0",
+        "jsdom-global": "^3.0.2",
+        "mocha": "^10.0.0",
+        "webpack": "^5.66.0",
+        "webpack-cli": "^4.9.1"
     },
     "scripts": {
         "test": "mocha ./tests/"

--- a/src/DataFrame.js
+++ b/src/DataFrame.js
@@ -213,11 +213,34 @@ class DataFrame extends Frame {
         }
     }
 
+    /**
+     * Replace values in the DataFrame.store with the return of the
+     * func applied to each value.
+     * @param {function} func - A function
+     * @param {boolean} notify - If true will try to call this.callback
+     */
     apply(func, notify=false){
         this.forEachPoint((p) => {
             this.putAt(p, func(this.getAt(p)), notify);
         });
     }
+
+    /**
+     * I do an (store) elemnent pairwise add operation for this and
+     * the df DataFrame (in place)
+     * NOTE: this and df must be equal as frames, ie their coordinates must match up
+     * @param {DataFrame} df - The dataframe to be added
+     * @param {boolean} notify - If true will try to call this.callback
+     */
+    add(df, notify=false){
+        if(!this.equals(df)){
+            throw "DataFrames must be equal as frames (dimensionally aligned) to add";
+        }
+        this.forEachPoint((p) => {
+            this.putAt(p, this.getAt(p) + df.getAt(p), notify);
+        });
+    }
+
 
     /**
      * I take a new frame and copy it into this DataFrame

--- a/src/DataFrame.js
+++ b/src/DataFrame.js
@@ -29,6 +29,7 @@ class DataFrame extends Frame {
         this.getAt = this.getAt.bind(this);
         this.copyFrom = this.copyFrom.bind(this);
         this.getDataArrayForFrame = this.getDataArrayForFrame.bind(this);
+        this.getDataSubFrame = this.getDataSubFrame.bind(this);
     }
 
     /**
@@ -170,6 +171,18 @@ class DataFrame extends Frame {
     }
 
     /**
+     * I return a DataFrame which contains the points (and data)
+     * of this frame starting at the specified (new) origin and corner.
+     */
+    getDataSubFrame(origin, corner){
+        const subframe =  new DataFrame(origin, corner);
+        subframe.forEachPoint((p) => {
+            subframe.putAt(p, this.getAt(p), false); // do not notify
+        })
+        return subframe;
+    }
+
+    /**
      * Respond with a 2d data array corresponding to
      * the contents of this DataFrame instance.
      * If `strict` is true, we use `minFrame` under the
@@ -198,6 +211,12 @@ class DataFrame extends Frame {
                 new Frame(this.origin, this.corner)
             );
         }
+    }
+
+    apply(func, notify=false){
+        this.forEachPoint((p) => {
+            this.putAt(p, func(this.getAt(p)), notify);
+        });
     }
 
     /**

--- a/src/DataFrame.js
+++ b/src/DataFrame.js
@@ -207,6 +207,9 @@ class DataFrame extends Frame {
      * does not contain the frame then I throw an error.
      **/
     copyFrom(frame, origin=[0, 0]){
+        if(!(frame instanceof DataFrame)){
+            throw "You must pass in a data frame to copy from";
+        }
         if(!this.intersection(frame).contains(frame)){
             throw "DataFrame too small to copy from frame at origin";
         }

--- a/src/DataFrame.js
+++ b/src/DataFrame.js
@@ -27,6 +27,7 @@ class DataFrame extends Frame {
         this.loadFromArray = this.loadFromArray.bind(this);
         this.putAt = this.putAt.bind(this);
         this.getAt = this.getAt.bind(this);
+        this.copyFrom = this.copyFrom.bind(this);
         this.getDataArrayForFrame = this.getDataArrayForFrame.bind(this);
     }
 
@@ -197,6 +198,19 @@ class DataFrame extends Frame {
                 new Frame(this.origin, this.corner)
             );
         }
+    }
+
+    /**
+     * I take a new frame and copy it into this DataFrame
+     * starting with the specified origin. If the frame doesn't
+     * "fit" ie if the intersection of frame with this DataFrame
+     * does not contain the frame then I throw an error.
+     **/
+    copyFrom(frame, origin=[0, 0]){
+        if(!this.intersection(frame).contains(frame)){
+            throw "DataFrame too small to copy from frame at origin";
+        }
+        this.loadFromArray(frame.toArray(), origin=origin);
     }
 
     /**

--- a/src/DataFrame.js
+++ b/src/DataFrame.js
@@ -233,12 +233,20 @@ class DataFrame extends Frame {
      * @param {boolean} notify - If true will try to call this.callback
      */
     add(df, notify=false){
-        if(!this.equals(df)){
-            throw "DataFrames must be equal as frames (dimensionally aligned) to add";
+        if(!this.size.equals(df.size)){
+            throw "DataFrames must be equal size to add";
         }
-        this.forEachPoint((p) => {
-            this.putAt(p, this.getAt(p) + df.getAt(p), notify);
-        });
+        // TODO: dumping DS's to arrays like this might cause performance issues
+        // we should consider something that will simulatenously iterate over points
+        // in both frames respecting the order
+        const this_array = this.toArray();
+        const df_array = df.toArray();
+        this_array.forEach((row, ridx) => {
+            this_array[ridx].forEach((value, cidx) => {
+                this_array[ridx][cidx] = value + df_array[ridx][cidx];
+            })
+        })
+        this.loadFromArray(this_array);
     }
 
 

--- a/tests/data-frame-loading-tests.js
+++ b/tests/data-frame-loading-tests.js
@@ -122,11 +122,11 @@ describe('DataFrame data tests', () => {
         });
     });
     describe("Operators", () => {
-        const frame = new DataFrame([0,0], [100, 100]);
-        frame.forEachPoint((p) => {
-            frame.putAt(p, p.x + p.y, false);
-        })
         it("Apply with function that return same value doens't change frame", () => {
+            const frame = new DataFrame([0,0], [100, 100]);
+            frame.forEachPoint((p) => {
+                frame.putAt(p, p.x + p.y, false);
+            })
             const expected = frame.copy();
             expected.store = frame.store;
             frame.apply((item) => {return item;});
@@ -134,6 +134,10 @@ describe('DataFrame data tests', () => {
             assert.deepEqual(expected.store, frame.store);
         });
         it("Apply with a more interesting function", () => {
+            const frame = new DataFrame([0,0], [100, 100]);
+            frame.forEachPoint((p) => {
+                frame.putAt(p, p.x + p.y, false);
+            })
             const expected = new DataFrame([0,0], [100, 100]);
             expected.forEachPoint((p) => {
                 expected.putAt(p, p.x + p.y + "_item", false);
@@ -141,6 +145,31 @@ describe('DataFrame data tests', () => {
             frame.apply((item) => {return item + "_item";});
             assert.isTrue(expected.equals(frame));
             assert.deepEqual(expected.store, frame.store);
+        });
+        it("Add two data frames", () => {
+            const frame = new DataFrame([0,0], [100, 100]);
+            frame.forEachPoint((p) => {
+                frame.putAt(p, p.x + p.y, false);
+            })
+            const another = new DataFrame([0,0], [100, 100]);
+            another.forEachPoint((p) => {
+                another.putAt(p, "_item", false);
+            })
+            const expected = new DataFrame([0,0], [100, 100]);
+            expected.forEachPoint((p) => {
+                expected.putAt(p, p.x + p.y + "_item", false);
+            })
+            frame.add(another);
+            assert.isTrue(expected.equals(frame));
+            assert.deepEqual(expected.store, frame.store);
+        });
+        it("Must be dimensionally aligned to add", () => {
+            const frame = new DataFrame([0,0], [100, 100]);
+            frame.forEachPoint((p) => {
+                frame.putAt(p, p.x + p.y, false);
+            })
+            const another = new DataFrame([10,10], [100, 100]);
+            expect(() => {frame.add(another)}).to.throw();
         });
     });
     describe("toArray / loadFromArray idempotency", () => {

--- a/tests/data-frame-loading-tests.js
+++ b/tests/data-frame-loading-tests.js
@@ -11,6 +11,7 @@ import {Frame} from "../src/Frame.js";
 import {DataFrame} from "../src/DataFrame.js";
 import {Point} from "../src/Point.js";
 import chai from "chai";
+import { expect } from "chai";
 const assert = chai.assert;
 
 // Add a special test case for comparing Points
@@ -26,58 +27,92 @@ assert.pointsEqual = function(firstPoint, secondPoint, msg){
     );
 };
 
-describe('Projecting total source frame to dest frame', () => {
-    let sourceFrame = new DataFrame([0,0], [1000,1000]);
-    sourceFrame.forEachPoint(aPoint => {
-        sourceFrame.putAt(aPoint, aPoint);
+describe('DataFrame data tests', () => {
+    describe('Projecting total source frame to dest frame', () => {
+        let sourceFrame = new DataFrame([0,0], [1000,1000]);
+        sourceFrame.forEachPoint(aPoint => {
+            sourceFrame.putAt(aPoint, aPoint);
+        });
+        let destFrame = new DataFrame([0,0], [2000,2000]);
+        let desiredSubframe = new Frame([50,30], [100,100]);
+
+        it('Can output array data of correct size', () => {
+            let arrayData = sourceFrame.getDataArrayForFrame(
+                desiredSubframe
+            );
+
+            assert.equal(arrayData.length, desiredSubframe.size.y + 1);
+            assert.equal(arrayData[0].length, desiredSubframe.size.x + 1);
+        });
+
+        it('Can load the arrayed data correctly into the dest data frame', () => {
+            let arrayData = sourceFrame.getDataArrayForFrame(
+                desiredSubframe
+            );
+            destFrame.loadFromArray(
+                arrayData,
+                desiredSubframe.origin
+            );
+
+            assert.pointsEqual(
+                sourceFrame.getAt(desiredSubframe.origin),
+                destFrame.getAt(desiredSubframe.origin)
+            );
+
+            assert.pointsEqual(
+                sourceFrame.getAt(desiredSubframe.corner),
+                destFrame.getAt(desiredSubframe.corner)
+            );
+        });
     });
-    let destFrame = new DataFrame([0,0], [2000,2000]);
-    let desiredSubframe = new Frame([50,30], [100,100]);
-
-    it('Can output array data of correct size', () => {
-        let arrayData = sourceFrame.getDataArrayForFrame(
-            desiredSubframe
-        );
-
-        assert.equal(arrayData.length, desiredSubframe.size.y + 1);
-        assert.equal(arrayData[0].length, desiredSubframe.size.x + 1);
+    describe("copy one frame into another", () => {
+        let sourceFrame = new DataFrame([10,10], [12, 12]);
+        sourceFrame.putAt([10,10], "TEST_1010");
+        sourceFrame.putAt([10,11], "TEST_1010");
+        sourceFrame.putAt([11,10], "TEST_1110");
+        sourceFrame.putAt([11,11], "TEST_1111");
+        it("target frame has the correct value", () => {
+            const targetFrame = new DataFrame([0,0], [100, 100]);
+            const expectedFrame = new DataFrame([0,0], [100, 100]);
+            expectedFrame.putAt([5,5], "TEST_1010");
+            expectedFrame.putAt([5,6], "TEST_1010");
+            expectedFrame.putAt([6,5], "TEST_1110");
+            expectedFrame.putAt([6,6], "TEST_1111");
+            targetFrame.copyFrom(sourceFrame, [5,5]);
+            assert.deepEqual(expectedFrame.store, targetFrame.store);
+        });
+        it("target frame has the correct value with default copy from origin", () => {
+            const targetFrame = new DataFrame([0,0], [100, 100]);
+            const expectedFrame = new DataFrame([0,0], [100, 100]);
+            expectedFrame.putAt([0,0], "TEST_1010");
+            expectedFrame.putAt([0,1], "TEST_1010");
+            expectedFrame.putAt([1,0], "TEST_1110");
+            expectedFrame.putAt([1,1], "TEST_1111");
+            targetFrame.copyFrom(sourceFrame);
+            assert.deepEqual(expectedFrame.store, targetFrame.store);
+        });
+        it("target will throw error if too small to accept copy", () => {
+            const targetFrame = new DataFrame([0,0], [10, 10]);
+            expect(() => {targetFrame.copyFrom(sourceFrame, [5,5])}).to.throw();
+        });
     });
-
-    it('Can load the arrayed data correctly into the dest data frame', () => {
-        let arrayData = sourceFrame.getDataArrayForFrame(
-            desiredSubframe
-        );
-        destFrame.loadFromArray(
-            arrayData,
-            desiredSubframe.origin
-        );
-
-        assert.pointsEqual(
-            sourceFrame.getAt(desiredSubframe.origin),
-            destFrame.getAt(desiredSubframe.origin)
-        );
-
-        assert.pointsEqual(
-            sourceFrame.getAt(desiredSubframe.corner),
-            destFrame.getAt(desiredSubframe.corner)
-        );
+    describe("toArray / loadFromArray idempotency", () => {
+        let sourceFrame = new DataFrame([0,0], [1000, 1000]);
+        beforeEach(() => {
+            sourceFrame.clear();
+        });
+        it("Has identical store when using defined values (example1)", () => {
+            sourceFrame.putAt([4,1], "TEST");
+            sourceFrame.putAt([2,3], "TEST");
+            let dataArray = sourceFrame.toArray();
+            let newFrame = new DataFrame(
+                sourceFrame.origin,
+                sourceFrame.corner
+            );
+            newFrame.loadFromArray(dataArray);
+            assert.deepEqual(newFrame.store, sourceFrame.store);
+        });
     });
 });
 
-describe("toArray / loadFromArray idempotency", () => {
-    let sourceFrame = new DataFrame([0,0], [1000, 1000]);
-    beforeEach(() => {
-        sourceFrame.clear();
-    });
-    it("Has identical store when using defined values (example1)", () => {
-        sourceFrame.putAt([4,1], "TEST");
-        sourceFrame.putAt([2,3], "TEST");
-        let dataArray = sourceFrame.toArray();
-        let newFrame = new DataFrame(
-            sourceFrame.origin,
-            sourceFrame.corner
-        );
-        newFrame.loadFromArray(dataArray);
-        assert.deepEqual(newFrame.store, sourceFrame.store);
-    });
-});
+

--- a/tests/data-frame-loading-tests.js
+++ b/tests/data-frame-loading-tests.js
@@ -100,6 +100,49 @@ describe('DataFrame data tests', () => {
             expect(() => {targetFrame.copyFrom([1, 2, 3])}).to.throw();
         });
     });
+    describe("Sub-DataFrame", () => {
+        const frame = new DataFrame([0,0], [1000, 1000]);
+        frame.putAt([10,10], "TEST_1010");
+        frame.putAt([10,11], "TEST_1010");
+        frame.putAt([11,10], "TEST_1110");
+        frame.putAt([11,11], "TEST_1111");
+        it("Sub-DataFrame has the correct frame and store", () => {
+            const subframe = frame.getDataSubFrame([10, 10], [20, 20]);
+            const expected = new DataFrame([10, 10], [20, 20]);
+            expected.putAt([10,10], "TEST_1010");
+            expected.putAt([10,11], "TEST_1010");
+            expected.putAt([11,10], "TEST_1110");
+            expected.putAt([11,11], "TEST_1111");
+            assert.isTrue(expected.equals(subframe));
+            assert.deepEqual(expected.store, subframe.store);
+        });
+        it("Both origin and corner must be in frame to get Sub-DataFrame", () => {
+            expect(() => {frame.getDataSubFrame([10, 10], [2000, 20])}).to.throw();
+            expect(() => {frame.getDataSubFrame([2000, 10], [2000, 20])}).to.throw();
+        });
+    });
+    describe("Operators", () => {
+        const frame = new DataFrame([0,0], [100, 100]);
+        frame.forEachPoint((p) => {
+            frame.putAt(p, p.x + p.y, false);
+        })
+        it("Apply with function that return same value doens't change frame", () => {
+            const expected = frame.copy();
+            expected.store = frame.store;
+            frame.apply((item) => {return item;});
+            assert.isTrue(expected.equals(frame));
+            assert.deepEqual(expected.store, frame.store);
+        });
+        it("Apply with a more interesting function", () => {
+            const expected = new DataFrame([0,0], [100, 100]);
+            expected.forEachPoint((p) => {
+                expected.putAt(p, p.x + p.y + "_item", false);
+            })
+            frame.apply((item) => {return item + "_item";});
+            assert.isTrue(expected.equals(frame));
+            assert.deepEqual(expected.store, frame.store);
+        });
+    });
     describe("toArray / loadFromArray idempotency", () => {
         let sourceFrame = new DataFrame([0,0], [1000, 1000]);
         beforeEach(() => {

--- a/tests/data-frame-loading-tests.js
+++ b/tests/data-frame-loading-tests.js
@@ -95,6 +95,10 @@ describe('DataFrame data tests', () => {
             const targetFrame = new DataFrame([0,0], [10, 10]);
             expect(() => {targetFrame.copyFrom(sourceFrame, [5,5])}).to.throw();
         });
+        it("source must be a data frame", () => {
+            const targetFrame = new DataFrame([0,0], [10, 10]);
+            expect(() => {targetFrame.copyFrom([1, 2, 3])}).to.throw();
+        });
     });
     describe("toArray / loadFromArray idempotency", () => {
         let sourceFrame = new DataFrame([0,0], [1000, 1000]);

--- a/tests/data-frame-loading-tests.js
+++ b/tests/data-frame-loading-tests.js
@@ -151,7 +151,7 @@ describe('DataFrame data tests', () => {
             frame.forEachPoint((p) => {
                 frame.putAt(p, p.x + p.y, false);
             })
-            const another = new DataFrame([0,0], [100, 100]);
+            const another = new DataFrame([10,10], [110, 110]);
             another.forEachPoint((p) => {
                 another.putAt(p, "_item", false);
             })


### PR DESCRIPTION
### Main Points ###

This method copies data from one data frame into another starting at a specified origin - essentially this is the same as [paste](https://github.com/darth-cheney/ap-sheet/blob/master/src/SyntheticClipboardHandler.js#L70) from the synthetic clipboard, but acts directly on the data frame itself. It's a convenience method but is useful since much a lot of interaction between sheets includes copying data from one to another. 

tests added
minor cleanup of tests and adding mocha as a requirement