### PR TITLE
Draggable Selections

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,21 +1,43 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-    <head>
-        <title>Basic Grid Tests</title>
-        <link rel="stylesheet" href="style.css">
-        <script type="module" src="../src/GridSheet.js"></script>
-        <script type="module" src="../src/SheetCell.js"></script>
-    </head>
-    <body>
-        <my-grid class="spreadsheet" id="table" rows="12" columns="3" expands="true">
-        </my-grid>
+  <head>
+    <title>Basic Grid Tests</title>
+    <link rel="stylesheet" href="style.css" />
+    <script type="module" src="../src/GridSheet.js"></script>
+    <script type="module" src="../src/SheetCell.js"></script>
+  </head>
+  <body>
+    <my-grid
+      class="spreadsheet"
+      id="table"
+      rows="12"
+      columns="3"
+      expands="true"
+    >
+    </my-grid>
 
-        <a href="two-tables.html">Click here for the two tables example</a>
-    </body>
-    <script>
-     document.addEventListener('DOMContentLoaded', () => {
-         let table = document.getElementById('table');
-         table.focus();
-     });
-    </script>
+    <a href="two-tables.html">Click here for the two tables example</a>
+  </body>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      let table = document.getElementById("table");
+      table.focus();
+
+      document.body.addEventListener("drop", (event) => {
+        let transferData = JSON.parse(event.dataTransfer.getData("text/json"));
+        let displayData = JSON.stringify(transferData, null, 4);
+        let container = document.createElement("div");
+        container.style.display = "block";
+        container.style.position = "absolute";
+        container.style.width = "300px";
+        container.textContent = displayData;
+        container.style.top = `${event.y}px`;
+        container.style.left = `${event.x}px`;
+        document.body.append(container);
+      });
+      document.body.addEventListener("dragover", (event) => {
+        event.preventDefault();
+      });
+    });
+  </script>
 </html>


### PR DESCRIPTION
## What ##
This PR updates `SelectionElements` so that they can be dragged and potentially dropped.
  
## Implementation ##
### Binding `keyDown` and `keyUp` to parent/host element ###
In order to override existing mouse behavior inside of a Sheet, we only enable the dragging of selections when a specific modifier key is pressed -- in this case, the Alt key.
  
However, key events will only be triggered when certain focusable elements are currently in focus. The way we handle this is to immediately bind the `keydown` and `keyup` events to the parent element or shadow host parent of the SelectionElement when it is connected. You can see that happening [here](https://github.com/darth-cheney/ap-sheet/blob/selection-draggable/src/SelectionElement.js#L58).
  
### `DataTransfer` Structure ###
When dragging starts, we create a DataTransfer entry of type `text/json` with the following keys, which describe themselves: `viewFrameOrigin`, `viewFrameCorner`, `relativeFrameOrigin`, `relativeFrameCorner`, `parentId`.
  
### Drop Events ###
It is up to implementors to handle drop events properly. 
  
## Example ##
The index page in the `/examples/` directory is enabled in such a way that holding Alt and dragging a selection out to the body will place a JSON string representation of the transfer data into the body at the absolute coordinates.