### PR TITLE
adding a read-only-view attribute to sheet

### DIFF
--- a/src/KeyHandler.js
+++ b/src/KeyHandler.js
@@ -144,7 +144,7 @@ class KeyHandler extends Object {
                 let cellElement = this.sheet.primaryFrame.elementAt(
                     this.sheet.selector.cursor
                 );
-                if(!cellElement.isEditing){
+                if(!this.sheet.hasAttribute("read-only-view") && !cellElement.isEditing){
                     cellElement.setAttribute('editing', true);
                     event.stopPropagation();
                 }

--- a/src/SheetCell.js
+++ b/src/SheetCell.js
@@ -204,7 +204,7 @@ class SheetCell extends HTMLElement {
     }
 
     handleDoubleClick(event){
-        if(!this.isEditing){
+        if(!this.parentElement.hasAttribute("read-only-view") && !this.isEditing){
             this.setAttribute('editing', true);
         }
     }


### PR DESCRIPTION
this prevents dblclick and enter-key events from putting a cell in editing mode