### PR TITLE
Delete Selection on Delete or Backspace Keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 package-lock.json
+/node_modules/.bin/acorn

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 package-lock.json
-/node_modules/.bin/acorn
+node_modules/

--- a/src/DataFrame.js
+++ b/src/DataFrame.js
@@ -202,6 +202,23 @@ class DataFrame extends Frame {
     }
 
     /**
+     * Clear out the intersection of the passed in
+     * Frame instance and any data within this Frame
+     */
+    clearFrame(aFrame) {
+        const intersectionFrame = this.intersection(aFrame);
+        if (!intersectionFrame.isEmpty) {
+            intersectionFrame.forEachPoint((point) => {
+                const key = `${point.x},${point.y}`;
+                delete this.store[key];
+            });
+            if (this.callback) {
+                this.callback(intersectionFrame);
+            }
+        }
+    }
+
+    /**
      * Replace values in the DataFrame.store with the return of the
      * func applied to each value.
      * @param {function} func - A function

--- a/src/GridSheet.js
+++ b/src/GridSheet.js
@@ -190,6 +190,7 @@ class GridSheet extends HTMLElement {
         this.handleColumnAdjustment = this.handleColumnAdjustment.bind(this);
         this.handleRowAdjustment = this.handleRowAdjustment.bind(this);
         this.handleCellEdited = this.handleCellEdited.bind(this);
+        this.handleDataFrameResized = this.handleDataFrameResized.bind(this);
     }
 
     connectedCallback() {
@@ -680,6 +681,17 @@ class GridSheet extends HTMLElement {
             event.detail.content
         );
         this.focus();
+    }
+
+    handleDataFrameResized(event) {
+        const maxRows = this.dataFrame.corner.y;
+        const maxCols = this.dataFrame.corner.x;
+        if (this.numRows > maxRows) {
+            this.setAttribute("rows", maxRows);
+        }
+        if (this.numCols > maxCols) {
+            this.setAttribute("columns", maxCols);
+        }
     }
 
     trackSelectionWithRowTabs() {

--- a/src/KeyHandler.js
+++ b/src/KeyHandler.js
@@ -143,6 +143,30 @@ class KeyHandler extends Object {
                 }
             }
         });
+        this.registerHandler("Delete", (event) => {
+            if (this.sheet.selector.selectionFrame.isEmpty) {
+                this.sheet.dataFrame.putAt(
+                    this.sheet.selector.anchor,
+                    undefined
+                );
+            } else {
+                this.sheet.dataFrame.clearFrame(
+                    this.sheet.selector.selectionFrame
+                );
+            }
+        });
+        this.registerHandler("Backspace", (event) => {
+            if (this.sheet.selector.selectionFrame.isEmpty) {
+                this.sheet.dataFrame.putAt(
+                    this.sheet.selector.anchor,
+                    undefined
+                );
+            } else {
+                this.sheet.dataFrame.clearFrame(
+                    this.sheet.selector.selectionFrame
+                );
+            }
+        });
     }
 
     usesModifierKeys(event) {

--- a/tests/sheet-element-tests.js
+++ b/tests/sheet-element-tests.js
@@ -2,6 +2,7 @@ import sinon from "sinon";
 import chai from "chai";
 import { expect } from "chai";
 import "../src/GridSheet.js";
+import { Point } from "../src/Point.js";
 import { DataFrame } from "../src/DataFrame.js";
 const assert = chai.assert;
 
@@ -35,6 +36,37 @@ describe("GridSheet Element Tests", () => {
         });
         it("calls the handler when loaded data expands the dataFrame", () => {
             assert.isTrue(handler.calledOnce);
+        });
+    });
+    describe("Can clear the primary selector using Delete key", () => {
+        let gridElement;
+        beforeEach(() => {
+            gridElement = document.createElement("my-grid");
+            document.body.append(gridElement);
+            gridElement.selector.selectFromAnchorTo(new Point(50, 50));
+        });
+
+        afterEach(() => {
+            gridElement.remove();
+        });
+
+        it("should delete 0,0 to 50,50 on Delete keydown", () => {
+            const keyEvent = new KeyboardEvent("keydown", { key: "Delete" });
+            gridElement.dispatchEvent(keyEvent);
+
+            assert.isFalse(gridElement.selector.selectionFrame.isEmpty);
+            gridElement.selector.selectionFrame.forEachPoint((aPoint) => {
+                assert.equal(gridElement.dataFrame.at(aPoint), undefined);
+            });
+        });
+        it("should delete 0,0 to 50,50 on Backspace keydown", () => {
+            const keyEvent = new KeyboardEvent("keydown", { key: "Backspace" });
+            gridElement.dispatchEvent(keyEvent);
+
+            assert.isFalse(gridElement.selector.selectionFrame.isEmpty);
+            gridElement.selector.selectionFrame.forEachPoint((aPoint) => {
+                assert.equal(gridElement.dataFrame.at(aPoint), undefined);
+            });
         });
     });
 });

--- a/utils/test-setup.js
+++ b/utils/test-setup.js
@@ -12,6 +12,7 @@ const resetDOM = () => {
     globalThis.customElements = dom.window.customElements;
     globalThis.CustomEvent = dom.window.CustomEvent;
     globalThis.ResizeObserver = ResizeObserver;
+    globalThis.KeyboardEvent = dom.window.KeyboardEvent;
 };
 
 globalThis.resetDOM = resetDOM;


### PR DESCRIPTION
## NOTE ##
Branched from #36 so needs to be rebased and merged after that has been merged.
  
## What ##
This PR addresses Issue #32 which asked that the primary selection be cleared when the user presses the Delete or Backspace keys.
  
## Implementation ##
We have added a new method, `clearFrame`, to the DataFrame, which works just like `clear` but limits the clearing to the intersection of the incoming frame and itself.
  
The rest is handled by normal KeyHandler settings.
  
## Tests ##
We have added a couple of tests to make sure that the data is being cleared behind the scenes.

## Trying it out ##
Run:
```
nodeenv --prebuilt --node=16.17.1 nodeenv && source nodeenv/bin/activate && npm install
python3 -m http.server
```
Then point your browser to localhost:8000/examples to load any example sheet. Highlighting and pressing delete or backspace should clear the values in the sheet.
  
## Closes ##
#32 