### PR TITLE
Frame `size` response

### DIFF
--- a/src/DataFrame.js
+++ b/src/DataFrame.js
@@ -120,9 +120,9 @@ class DataFrame extends Frame {
             // need to check if this simply an extension of the DF, ie
             // we are adding rows or columns
             // Note: appending must continue the row/columns, ie no jumps
-            const appendRows = origin.x == 0 && (origin.y - 1) == this.size.y;
-            const appendColumns = origin.y == 0 && (origin.x - 1) == this.size.x;
-            if(!appendRows && !appendColumns){
+            const appendRows = origin.x == 0 && origin.y == this.size.y;
+            const appendColumns = origin.y == 0 && origin.x == this.size.x;
+            if (!appendRows && !appendColumns) {
                 throw `${origin} not contained in this DataFrame and is not an append of rows or columns`;
             }
         }

--- a/src/Frame.js
+++ b/src/Frame.js
@@ -466,8 +466,8 @@ class Frame {
         if (this.isEmpty) {
             return new Point([0, 0]);
         }
-        let x = this.corner.x - this.origin.x;
-        let y = this.corner.y - this.origin.y;
+        let x = this.corner.x - this.origin.x + 1;
+        let y = this.corner.y - this.origin.y + 1;
         return new Point([x, y]);
     }
 

--- a/src/PrimaryGridFrame.js
+++ b/src/PrimaryGridFrame.js
@@ -327,11 +327,12 @@ class PrimaryGridFrame extends GridElementsFrame {
      */
     shiftRightBy(amount) {
         let nextX = this.dataOffset.x + amount;
-        let nextRight = nextX + (this.viewFrame.size.x + this.numLockedColumns);
+        let nextRight =
+            nextX + (this.viewFrame.size.x - 1 + this.numLockedColumns);
         if (nextRight >= this.dataFrame.right) {
             nextX =
                 this.dataFrame.right -
-                (this.numLockedColumns + this.viewFrame.size.x);
+                (this.numLockedColumns + (this.viewFrame.size.x - 1));
         }
         this.dataOffset.x = nextX;
         this.updateCellContents();
@@ -376,11 +377,12 @@ class PrimaryGridFrame extends GridElementsFrame {
      */
     shiftDownBy(amount, debug = false) {
         let nextY = this.dataOffset.y + amount;
-        let nextBottom = nextY + (this.viewFrame.size.y + this.numLockedRows);
+        let nextBottom =
+            nextY + (this.viewFrame.size.y - 1 + this.numLockedRows);
         if (nextBottom >= this.dataFrame.bottom) {
             nextY =
                 this.dataFrame.bottom -
-                (this.numLockedRows + this.viewFrame.size.y);
+                (this.numLockedRows + (this.viewFrame.size.y - 1));
         }
         this.dataOffset.y = nextY;
         this.updateCellContents();
@@ -415,7 +417,7 @@ class PrimaryGridFrame extends GridElementsFrame {
      * an amount equivalent to my own total width
      */
     pageRight() {
-        let amount = this.relativeViewFrame.size.x;
+        let amount = this.relativeViewFrame.size.x - 1;
         this.shiftRightBy(amount);
     }
 
@@ -424,7 +426,7 @@ class PrimaryGridFrame extends GridElementsFrame {
      * an amount equivalent to my own total width
      */
     pageLeft() {
-        let amount = this.relativeViewFrame.size.x;
+        let amount = this.relativeViewFrame.size.x - 1;
         this.shiftLeftBy(amount);
     }
 
@@ -433,7 +435,7 @@ class PrimaryGridFrame extends GridElementsFrame {
      * an amount equivalent to my own total height
      */
     pageUp() {
-        let amount = this.relativeViewFrame.size.y;
+        let amount = this.relativeViewFrame.size.y - 1;
         this.shiftUpBy(amount);
     }
 
@@ -442,7 +444,7 @@ class PrimaryGridFrame extends GridElementsFrame {
      * an amount equivalent to my own total height
      */
     pageDown() {
-        let amount = this.relativeViewFrame.size.y;
+        let amount = this.relativeViewFrame.size.y - 1;
         this.shiftDownBy(amount);
     }
 

--- a/tests/data-frame-loading-tests.js
+++ b/tests/data-frame-loading-tests.js
@@ -27,6 +27,21 @@ assert.pointsEqual = function (firstPoint, secondPoint, msg) {
 };
 
 describe("DataFrame data tests", () => {
+    describe.skip("Basic loadFromArray tests", () => {
+        describe("2x3 Source Array", () => {
+            let sourceArray = [
+                [1, 2, 3],
+                [4, 5, 6],
+            ];
+            let dataFrame = new DataFrame([0, 0], [99, 99]);
+            before(async () => {
+                await dataFrame.loadFromArray(sourceArray);
+            });
+            it("Has the correct size", () => {
+                assert.isFalse(true);
+            });
+        });
+    });
     describe("Projecting total source frame to dest frame", () => {
         let sourceFrame = new DataFrame([0, 0], [1000, 1000]);
         sourceFrame.forEachPoint((aPoint) => {
@@ -38,8 +53,8 @@ describe("DataFrame data tests", () => {
         it("Can output array data of correct size", () => {
             let arrayData = sourceFrame.getDataArrayForFrame(desiredSubframe);
 
-            assert.equal(arrayData.length, desiredSubframe.size.y + 1);
-            assert.equal(arrayData[0].length, desiredSubframe.size.x + 1);
+            assert.equal(arrayData.length, desiredSubframe.size.y);
+            assert.equal(arrayData[0].length, desiredSubframe.size.x);
         });
 
         it("Can load the arrayed data correctly into the dest data frame", () => {

--- a/tests/data-frame-tests.js
+++ b/tests/data-frame-tests.js
@@ -107,8 +107,8 @@ describe("DataFrame Generic Tests", () => {
         sourceFrame.putAt([4, 1], "TEST");
         sourceFrame.putAt([2, 3], "TEST");
         let dataArray = sourceFrame.toArray();
-        let expectedRowLength = sourceFrame.size.y + 1;
-        let expectedColumnLength = sourceFrame.size.x + 1;
+        let expectedRowLength = sourceFrame.size.y;
+        let expectedColumnLength = sourceFrame.size.x;
         assert.equal(dataArray[0].length, expectedRowLength);
         assert.equal(dataArray.length, expectedColumnLength);
     });

--- a/tests/primary-frame-shift-tests.js
+++ b/tests/primary-frame-shift-tests.js
@@ -93,7 +93,7 @@ describe("PrimaryFrame Shifting with no locked cols or rows", () => {
          */
         let primaryFrame = new PrimaryFrame(exampleDataFrame, [6, 3]);
         let expectedA = new Point([
-            exampleDataFrame.corner.x - primaryFrame.viewFrame.size.x,
+            exampleDataFrame.corner.x - (primaryFrame.viewFrame.size.x - 1),
             0,
         ]);
         let expectedB = exampleDataFrame.topRight;
@@ -281,11 +281,11 @@ describe("PrimaryFrame Shifting with no locked cols or rows", () => {
 
         let expectedA = new Point([
             1,
-            exampleDataFrame.bottom - primaryFrame.viewFrame.size.y,
+            exampleDataFrame.bottom - (primaryFrame.viewFrame.size.y - 1),
         ]);
         let expectedB = new Point([
             7,
-            exampleDataFrame.bottom - primaryFrame.viewFrame.size.y,
+            exampleDataFrame.bottom - (primaryFrame.viewFrame.size.y - 1),
         ]);
         let expectedC = new Point([1, exampleDataFrame.bottom]);
         let expectedE = new Point([7, exampleDataFrame.bottom]);
@@ -429,7 +429,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         let expectedViewOrigin = new Point([0, 2]);
         let expectedRowsCorner = new Point([6, 1]);
         let expectedViewCorner = new Point([6, 3]);
-        let expectedViewFrameSize = new Point([6, 1]);
+        let expectedViewFrameSize = new Point([7, 2]);
 
         assert.pointsEqual(relLockedRows.origin, expectedRowsOrigin);
         assert.pointsEqual(relLockedRows.corner, expectedRowsCorner);
@@ -560,7 +560,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has the correct origin and corner for the relative view frame", () => {
             let relativeView = primaryFrame.relativeViewFrame;
             let expectedOrigin = new Point([
-                primaryFrame.dataFrame.right - relativeView.size.x,
+                primaryFrame.dataFrame.right - (relativeView.size.x - 1),
                 2,
             ]);
             let expectedCorner = new Point([primaryFrame.dataFrame.right, 3]);
@@ -572,7 +572,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has the correct origin and corner for the relative locked rows frame", () => {
             let relativeRows = primaryFrame.relativeLockedRowsFrame;
             let expectedOrigin = new Point([
-                primaryFrame.dataFrame.right - relativeRows.size.x,
+                primaryFrame.dataFrame.right - (relativeRows.size.x - 1),
                 0,
             ]);
             let expectedCorner = new Point([primaryFrame.dataFrame.right, 1]);
@@ -602,7 +602,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has the correct data from dataFrame at relative locked rows corners", () => {
             let relativeRows = primaryFrame.relativeLockedRowsFrame;
             let expectedOriginData = new Point([
-                primaryFrame.dataFrame.right - relativeRows.size.x,
+                primaryFrame.dataFrame.right - (relativeRows.size.x - 1),
                 0,
             ]);
             let expectedCornerData = new Point([
@@ -655,7 +655,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has correct origin and corner for relative view frame", () => {
             let relativeView = primaryFrame.relativeViewFrame;
             let expectedOrigin = new Point([
-                primaryFrame.dataFrame.right - relativeView.size.x - 1,
+                primaryFrame.dataFrame.right - relativeView.size.x,
                 2,
             ]);
             let expectedCorner = new Point([
@@ -670,7 +670,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has correct origin and corner for relative locked rows frame", () => {
             let relativeRows = primaryFrame.relativeLockedRowsFrame;
             let expectedOrigin = new Point([
-                primaryFrame.dataFrame.right - relativeRows.size.x - 1,
+                primaryFrame.dataFrame.right - relativeRows.size.x,
                 0,
             ]);
             let expectedCorner = new Point([
@@ -685,7 +685,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has correct data from dataFrame at relative view corners", () => {
             let relativeView = primaryFrame.relativeViewFrame;
             let expectedOriginData = new Point([
-                primaryFrame.dataFrame.right - relativeView.size.x - 1,
+                primaryFrame.dataFrame.right - relativeView.size.x,
                 2,
             ]);
             let expectedCornerData = new Point([
@@ -706,7 +706,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has correct data from dataFrame at relative rows frame corners", () => {
             let relativeRows = primaryFrame.relativeLockedRowsFrame;
             let expectedOriginData = new Point([
-                primaryFrame.dataFrame.right - relativeRows.size.x - 1,
+                primaryFrame.dataFrame.right - relativeRows.size.x,
                 0,
             ]);
             let expectedCornerData = new Point([
@@ -922,7 +922,8 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
 
         it("Has the correct dataOffset", () => {
             let totalRows =
-                primaryFrame.numLockedRows + primaryFrame.viewFrame.size.y;
+                primaryFrame.numLockedRows +
+                (primaryFrame.viewFrame.size.y - 1);
             let yOffset = primaryFrame.dataFrame.bottom - totalRows;
             let expectedOffset = new Point([0, yOffset]);
             assert.pointsEqual(primaryFrame.dataOffset, expectedOffset);
@@ -932,10 +933,11 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
             let relativeView = primaryFrame.relativeViewFrame;
             let expectedOrigin = new Point([
                 0,
-                primaryFrame.dataFrame.bottom - primaryFrame.viewFrame.size.y,
+                primaryFrame.dataFrame.bottom -
+                    (primaryFrame.viewFrame.size.y - 1),
             ]);
             let expectedCorner = new Point([
-                primaryFrame.viewFrame.size.x,
+                primaryFrame.viewFrame.size.x - 1,
                 primaryFrame.dataFrame.bottom,
             ]);
 
@@ -946,7 +948,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has the correct origin and corner for the relative locked rows", () => {
             let relativeRows = primaryFrame.relativeLockedRowsFrame;
             let expectedOrigin = new Point([0, 0]);
-            let expectedCorner = new Point([primaryFrame.size.x, 1]);
+            let expectedCorner = new Point([primaryFrame.size.x - 1, 1]);
 
             assert.pointsEqual(relativeRows.origin, expectedOrigin);
             assert.pointsEqual(relativeRows.corner, expectedCorner);
@@ -956,10 +958,11 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
             let relativeView = primaryFrame.relativeViewFrame;
             let expectedOriginData = new Point([
                 0,
-                primaryFrame.dataFrame.bottom - primaryFrame.viewFrame.size.y,
+                primaryFrame.dataFrame.bottom -
+                    (primaryFrame.viewFrame.size.y - 1),
             ]);
             let expectedCornerData = new Point([
-                primaryFrame.viewFrame.size.x,
+                primaryFrame.viewFrame.size.x - 1,
                 primaryFrame.dataFrame.bottom,
             ]);
             let actualOriginData = primaryFrame.dataFrame.getAt(
@@ -976,7 +979,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has the correct data from dataFrame at relative locked rows corners", () => {
             let relativeRows = primaryFrame.relativeLockedRowsFrame;
             let expectedOriginData = new Point([0, 0]);
-            let expectedCornerData = new Point([primaryFrame.size.x, 1]);
+            let expectedCornerData = new Point([primaryFrame.size.x - 1, 1]);
             let actualOriginData = primaryFrame.dataFrame.getAt(
                 relativeRows.origin
             );
@@ -1027,7 +1030,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
                 primaryFrame.dataFrame.bottom - 2,
             ]);
             let expectedCorner = new Point([
-                primaryFrame.size.x,
+                primaryFrame.size.x - 1,
                 primaryFrame.dataFrame.bottom - 1,
             ]);
 
@@ -1038,7 +1041,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has the correct origin and corner for the relative locked rows", () => {
             let relativeRows = primaryFrame.relativeLockedRowsFrame;
             let expectedOrigin = new Point([0, 0]);
-            let expectedCorner = new Point([primaryFrame.size.x, 1]);
+            let expectedCorner = new Point([primaryFrame.size.x - 1, 1]);
 
             assert.pointsEqual(relativeRows.origin, expectedOrigin);
             assert.pointsEqual(relativeRows.corner, expectedCorner);
@@ -1051,7 +1054,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
                 primaryFrame.dataFrame.bottom - 2,
             ]);
             let expectedCornerData = new Point([
-                primaryFrame.size.x,
+                primaryFrame.size.x - 1,
                 primaryFrame.dataFrame.bottom - 1,
             ]);
             let actualOriginData = primaryFrame.dataFrame.getAt(
@@ -1068,7 +1071,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has the correct data from dataFrame at relative locked rows corners", () => {
             let relativeRows = primaryFrame.relativeLockedRowsFrame;
             let expectedOriginData = new Point([0, 0]);
-            let expectedCornerData = new Point([primaryFrame.size.x, 1]);
+            let expectedCornerData = new Point([primaryFrame.size.x - 1, 1]);
             let actualOriginData = primaryFrame.dataFrame.getAt(
                 relativeRows.origin
             );
@@ -1131,7 +1134,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has the correct origin and corner for the relative locked rows", () => {
             let relativeRows = primaryFrame.relativeLockedRowsFrame;
             let expectedOrigin = new Point([0, 0]);
-            let expectedCorner = new Point([primaryFrame.size.x, 1]);
+            let expectedCorner = new Point([primaryFrame.size.x - 1, 1]);
 
             assert.pointsEqual(relativeRows.origin, expectedOrigin);
             assert.pointsEqual(relativeRows.corner, expectedCorner);
@@ -1155,7 +1158,7 @@ describe("PrimaryFrame Shifting with 2 locked rows", () => {
         it("Has the correct data from dataFrame for the relative locked rows corners", () => {
             let relativeRows = primaryFrame.relativeLockedRowsFrame;
             let expectedOriginData = new Point([0, 0]);
-            let expectedCornerData = new Point([primaryFrame.size.x, 1]);
+            let expectedCornerData = new Point([primaryFrame.size.x - 1, 1]);
             let actualOriginData = primaryFrame.dataFrame.getAt(
                 relativeRows.origin
             );


### PR DESCRIPTION
## What ##
This PR deals with Issue #29, which points out how we are inconsistently giving the Frame `size` across the codebase.
  
In this branch we are saying strictly that the `size` of a Frame is a Point whose width and height values are equal to the _length_ of the row and column arrays. Therefore, for `Frame([0,0], [5,6])`, the size is `Point([6, 7])`.
  
## Implementation ##
The fix itself was small, but it had ramifications throughout the codebase and in the tests. I have dealt with all of the references I could find, and all tests seem to be passing
  
## Remaining Work ##
I would like to include a specific test case for the example given in #29, once we have clarification of reproducing it.