### PR TITLE
Issue 43 Fix

### DIFF
--- a/src/SelectionElement.js
+++ b/src/SelectionElement.js
@@ -99,9 +99,9 @@ class SelectionElement extends HTMLElement {
         //let frame = this.viewFrame.intersection(this.relativeFrame);
         let frame = this.viewFrame;
         this.style.setProperty("--col-start", frame.origin.x + 1);
-        this.style.setProperty("--col-end", frame.size.x + 1);
+        this.style.setProperty("--col-end", frame.size.x);
         this.style.setProperty("--row-start", frame.origin.y + 1);
-        this.style.setProperty("--row-end", frame.size.y + 1);
+        this.style.setProperty("--row-end", frame.size.y);
     }
 
     updateFromViewFrame(aFrame) {


### PR DESCRIPTION
## What ##
After we adjusted the meaning of `size()` for frames, the `SelectionElement` retained an off-by-one error in how it highlights grid regions. This PR fixes the issue.
  
## Closes ##
#43 