### PR TITLE
Adding init pattern for DataStore

### DIFF
--- a/src/DataStore.js
+++ b/src/DataStore.js
@@ -14,11 +14,17 @@ class DataStore {
         // Point
         this._cache = {};
 
+        // The following flag is checked by
+        // any consumer to determine if the
+        // store has completed its init.
+        this.isReady = false;
+
         // A set of subscriber objects that
         // will be notified whenever data changes
         this.subscribers = new Set();
 
         // Bind instance methods
+        this.init = this.init.bind(this);
         this.notify = this.notify.bind(this);
         this.loadFromArray = this.loadFromArray.bind(this);
         this.putAt = this.putAt.bind(this);
@@ -30,6 +36,24 @@ class DataStore {
         this.clearData = this.clearData.bind(this);
         this.clearAllPersisted = this.clearAllPersisted.bind(this);
         this.clearPersistedData = this.clearPersistedData.bind(this);
+    }
+
+    /**
+     * Perform any needed initialization in
+     * order to be marked as 'ready'.
+     * Subclasses should override.
+     */
+    init() {
+        // return new Promise((resolve, reject) => {
+        //     setTimeout(() => {
+        //         this.isReady = true;
+        //         resolve(true);
+        //     }, 1500);
+        // });
+
+        return new Promise((resolve, reject) => {
+            resolve((this.isReady = true));
+        });
     }
 
     /**

--- a/src/DataStore.js
+++ b/src/DataStore.js
@@ -204,7 +204,7 @@ class DataStore {
         if (notify) {
             const endCoordinate = [
                 startCoordinate[0] + maxLength - 1,
-                startCoordinate[1] + data.length - 1
+                startCoordinate[1] + data.length - 1,
             ];
             this.notify(startCoordinate, endCoordinate);
         }
@@ -269,7 +269,8 @@ class DataStore {
      * from any backing datastore
      */
     async clearAllPersisted(notify = true) {
-        this.clearPersistedFrame(this, notify);
+        // No-op in the default DataStore.
+        // Subclasses should override as needed
     }
 
     /**

--- a/src/PrimaryGridFrame.js
+++ b/src/PrimaryGridFrame.js
@@ -71,6 +71,7 @@ class PrimaryGridFrame extends GridElementsFrame {
         this.pageDown = this.pageDown.bind(this);
         this.pageLeft = this.pageLeft.bind(this);
         this.pageRight = this.pageRight.bind(this);
+        this.getDataAt = this.getDataAt.bind(this);
         this.triggerAfterShift = this.triggerAfterShift.bind(this);
     }
 
@@ -446,6 +447,19 @@ class PrimaryGridFrame extends GridElementsFrame {
     pageDown() {
         let amount = this.relativeViewFrame.size.y - 1;
         this.shiftDownBy(amount);
+    }
+
+    /**
+     * A wrapper for this.dataStore.getAt
+     * that first checks to make sure the store
+     * is ready. If it isn't, it simply returns
+     * undefined, thus rendering an empty cell.
+     */
+    getDataAt(location) {
+        if (this.dataStore.isReady) {
+            return this.dataStore.getAt(location);
+        }
+        return undefined; // Will render empty cell
     }
 
     /**


### PR DESCRIPTION
## What
This commit adds an asychronous `init()` method to all DataStore instances. When resolved, the init method will set the DataStore's `isReady` property to `true`.

GridSheet and PrimaryFrame now make use of init() / isReady, so that in the future we can asynchronously set up a sheet and have it display a loader in the meantime.
  
## Loader
The "loader" display animation is a temporary holder until we can get a design pass on it.
  
## `DataStore` restoration
Note also that **we are restoring plain `DataStore` as the class for Gridsheet's default store**. IDB was no longer working.
  
## Trying it out
To see what the current loader looks like in action, [uncomment this block](https://github.com/darth-cheney/ap-sheet/blob/eric-datastore-ready/src/DataStore.js#L47-L52) (and then comment the block below it)